### PR TITLE
Refactor user share token balance provider into service

### DIFF
--- a/packages/tempus-client_v2/src/components/app/App.tsx
+++ b/packages/tempus-client_v2/src/components/app/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { LanguageContext, defaultLanguageContextValue } from '../../context/languageContext';
 import { ETHBalanceContext, defaultETHBalanceContextValue } from '../../context/ethBalanceContext';
@@ -9,6 +9,7 @@ import {
 } from '../../context/pendingTransactionsContext';
 import { UserSettingsContext, defaultUserSettingsContextValue } from '../../context/userSettingsContext';
 import ETHBalanceProvider from '../../providers/ethBalanceProvider';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import NotificationContainer from '../notification/NotificationContainer';
 import NavBar from '../navbar/NavBar';
 import Main from '../main/Main';
@@ -21,6 +22,17 @@ const App = () => {
   const [ethBalance, setETHBalance] = useState(defaultETHBalanceContextValue);
   const [walletData, setWalletData] = useState(defaultWalletContextValue);
   const [pendingTransactions, setPendingTransactions] = useState(defaultPendingTransactionsContextValue);
+
+  // Initialize user share token balance provider every time user wallet address changes
+  useEffect(() => {
+    if (!walletData.userWalletAddress) {
+      return;
+    }
+
+    getUserShareTokenBalanceProvider({
+      userWalletAddress: walletData.userWalletAddress,
+    }).init();
+  }, [walletData.userWalletAddress]);
 
   return (
     <UserSettingsContext.Provider value={{ ...userSettings, setUserSettings }}>

--- a/packages/tempus-client_v2/src/components/deposit/Deposit.tsx
+++ b/packages/tempus-client_v2/src/components/deposit/Deposit.tsx
@@ -3,6 +3,7 @@ import { Downgraded, useState as useHookState } from '@hookstate/core';
 import { ethers, BigNumber } from 'ethers';
 import { catchError } from 'rxjs';
 import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import { LanguageContext } from '../../context/languageContext';
 import { WalletContext } from '../../context/walletContext';
 import { Ticker } from '../../interfaces/Token';
@@ -184,7 +185,12 @@ const Deposit: FC<DepositProps> = ({ narrow, poolDataAdapter }) => {
 
   const onExecuted = useCallback(() => {
     setAmount('');
-  }, []);
+
+    // Trigger user pool share balance update when execute is finished
+    getUserShareTokenBalanceProvider({
+      userWalletAddress,
+    }).fetchForPool(selectedPoolAddress);
+  }, [selectedPoolAddress, userWalletAddress]);
 
   const onApproveChange = useCallback(approved => {
     setTokensApproved(approved);

--- a/packages/tempus-client_v2/src/components/earlyRedeem/EarlyRedeem.tsx
+++ b/packages/tempus-client_v2/src/components/earlyRedeem/EarlyRedeem.tsx
@@ -3,6 +3,7 @@ import { Downgraded, useState as useHookState } from '@hookstate/core';
 import { ethers, BigNumber } from 'ethers';
 import { catchError, combineLatest } from 'rxjs';
 import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import getPoolDataAdapter from '../../adapters/getPoolDataAdapter';
 import { LanguageContext } from '../../context/languageContext';
 import { WalletContext } from '../../context/walletContext';
@@ -20,6 +21,7 @@ import SectionContainer from '../sectionContainer/SectionContainer';
 import Spacer from '../spacer/spacer';
 import TokenSelector from '../tokenSelector/tokenSelector';
 import Typography from '../typography/Typography';
+
 import './EarlyRedeem.scss';
 
 const EarlyRedeem: FC = () => {
@@ -270,7 +272,12 @@ const EarlyRedeem: FC = () => {
 
   const onExecuted = useCallback(() => {
     setAmount('');
-  }, []);
+
+    // Trigger user pool share balance update when execute is finished
+    getUserShareTokenBalanceProvider({
+      userWalletAddress,
+    }).fetchForPool(selectedPoolAddress);
+  }, [selectedPoolAddress, userWalletAddress]);
 
   return (
     <div className="tc__earlyRedeem">

--- a/packages/tempus-client_v2/src/components/mint/Mint.tsx
+++ b/packages/tempus-client_v2/src/components/mint/Mint.tsx
@@ -3,6 +3,7 @@ import { Downgraded, useState as useHookState } from '@hookstate/core';
 import { ethers, BigNumber } from 'ethers';
 import { catchError } from 'rxjs';
 import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import getPoolDataAdapter from '../../adapters/getPoolDataAdapter';
 import { LanguageContext } from '../../context/languageContext';
 import { WalletContext } from '../../context/walletContext';
@@ -22,6 +23,7 @@ import Spacer from '../spacer/spacer';
 import TokenSelector from '../tokenSelector/tokenSelector';
 import Typography from '../typography/Typography';
 import TokenIcon from '../tokenIcon';
+
 import './Mint.scss';
 
 type MintInProps = {
@@ -178,7 +180,12 @@ const Mint: FC<MintInProps> = ({ narrow }) => {
 
   const onExecuted = useCallback(() => {
     setAmount('');
-  }, []);
+
+    // Trigger user pool share balance update when execute is finished
+    getUserShareTokenBalanceProvider({
+      userWalletAddress,
+    }).fetchForPool(selectedPoolAddress);
+  }, [selectedPoolAddress, userWalletAddress]);
 
   const onApproveChange = useCallback(approved => {
     setTokensApproved(approved);

--- a/packages/tempus-client_v2/src/components/operations/Operations.tsx
+++ b/packages/tempus-client_v2/src/components/operations/Operations.tsx
@@ -6,7 +6,6 @@ import { LanguageContext } from '../../context/languageContext';
 import { WalletContext } from '../../context/walletContext';
 import { TransactionView } from '../../interfaces/TransactionView';
 import UserLPTokenBalanceProvider from '../../providers/userLPTokenBalanceProvider';
-import UserShareTokenBalanceProvider from '../../providers/userShareTokenBalanceProvider';
 import CurrentPosition from '../currentPosition/CurrentPosition';
 import Deposit from '../deposit/Deposit';
 import EarlyRedeem from '../earlyRedeem/EarlyRedeem';
@@ -97,7 +96,6 @@ const Operations = () => {
           </div>
         )}
       </div>
-      <UserShareTokenBalanceProvider />
       <UserLPTokenBalanceProvider />
     </div>
   );

--- a/packages/tempus-client_v2/src/components/provideLiquidity/ProvideLiquidity.tsx
+++ b/packages/tempus-client_v2/src/components/provideLiquidity/ProvideLiquidity.tsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { ethers, BigNumber } from 'ethers';
 import { Downgraded, useState as useHookState } from '@hookstate/core';
 import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import { LanguageContext } from '../../context/languageContext';
 import { WalletContext } from '../../context/walletContext';
 import getText from '../../localisation/getText';
@@ -315,7 +316,12 @@ const ProvideLiquidity = () => {
   const onExecuted = useCallback(() => {
     setPrincipalsAmount('');
     setYieldsAmount('');
-  }, []);
+
+    // Trigger user pool share balance update when execute is finished
+    getUserShareTokenBalanceProvider({
+      userWalletAddress,
+    }).fetchForPool(selectedPoolAddress);
+  }, [selectedPoolAddress, userWalletAddress]);
 
   const principalsBalanceFormatted = useMemo(() => {
     if (!userPrincipalsBalance) {

--- a/packages/tempus-client_v2/src/components/removeLiquidity/RemoveLiquidity.tsx
+++ b/packages/tempus-client_v2/src/components/removeLiquidity/RemoveLiquidity.tsx
@@ -1,7 +1,8 @@
 import { Downgraded, useState as useHookState } from '@hookstate/core';
-import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { BigNumber, ethers } from 'ethers';
+import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import { LanguageContext } from '../../context/languageContext';
 import { WalletContext } from '../../context/walletContext';
 import getText from '../../localisation/getText';
@@ -33,6 +34,7 @@ const RemoveLiquidity = () => {
   const [tokensApproved, setTokensApproved] = useState<boolean>(false);
   const [estimateInProgress, setEstimateInProgress] = useState<boolean>(false);
 
+  const selectedPoolAddress = selectedPool.attach(Downgraded).get();
   const ammAddress = staticPoolData[selectedPool.get()].ammAddress.attach(Downgraded).get();
   const principalsAddress = staticPoolData[selectedPool.get()].principalsAddress.attach(Downgraded).get();
   const yieldsAddress = staticPoolData[selectedPool.get()].yieldsAddress.attach(Downgraded).get();
@@ -107,7 +109,12 @@ const RemoveLiquidity = () => {
 
   const onExecuted = useCallback(() => {
     setAmount('');
-  }, []);
+
+    // Trigger user pool share balance update when execute is finished
+    getUserShareTokenBalanceProvider({
+      userWalletAddress,
+    }).fetchForPool(selectedPoolAddress);
+  }, [selectedPoolAddress, userWalletAddress]);
 
   const lpTokenBalanceFormatted = useMemo(() => {
     if (!userLPTokenBalance) {

--- a/packages/tempus-client_v2/src/components/swap/Swap.tsx
+++ b/packages/tempus-client_v2/src/components/swap/Swap.tsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { BigNumber, ethers } from 'ethers';
 import { Downgraded, useState as useHookState } from '@hookstate/core';
 import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import { LanguageContext } from '../../context/languageContext';
 import { WalletContext } from '../../context/walletContext';
 import { PoolShares, Ticker } from '../../interfaces/Token';
@@ -162,7 +163,12 @@ const Swap = () => {
 
   const onExecuted = useCallback(() => {
     setAmount('');
-  }, []);
+
+    // Trigger user pool share balance update when execute is finished
+    getUserShareTokenBalanceProvider({
+      userWalletAddress,
+    }).fetchForPool(selectedPoolAddress);
+  }, [selectedPoolAddress, userWalletAddress]);
 
   // Fetch receive amount
   useEffect(() => {

--- a/packages/tempus-client_v2/src/components/withdraw/Withdraw.tsx
+++ b/packages/tempus-client_v2/src/components/withdraw/Withdraw.tsx
@@ -3,6 +3,7 @@ import { ethers, BigNumber } from 'ethers';
 import { Downgraded, useState as useHookState } from '@hookstate/core';
 import { combineLatest } from 'rxjs';
 import { dynamicPoolDataState, selectedPoolState, staticPoolDataState } from '../../state/PoolDataState';
+import getUserShareTokenBalanceProvider from '../../providers/getUserShareTokenBalanceProvider';
 import getPoolDataAdapter from '../../adapters/getPoolDataAdapter';
 import { WalletContext } from '../../context/walletContext';
 import { LanguageContext } from '../../context/languageContext';
@@ -34,7 +35,7 @@ const Withdraw: FC<WithdrawOutProps> = ({ onWithdraw }) => {
   const dynamicPoolData = useHookState(dynamicPoolDataState);
   const staticPoolData = useHookState(staticPoolDataState);
 
-  const { userWalletSigner } = useContext(WalletContext);
+  const { userWalletSigner, userWalletAddress } = useContext(WalletContext);
   const { language } = useContext(LanguageContext);
   const { slippage } = useContext(UserSettingsContext);
 
@@ -280,6 +281,15 @@ const Withdraw: FC<WithdrawOutProps> = ({ onWithdraw }) => {
     lpTokenAmount,
   ]);
 
+  const onExecuted = useCallback(() => {
+    onWithdraw();
+
+    // Trigger user pool share balance update when execute is finished
+    getUserShareTokenBalanceProvider({
+      userWalletAddress,
+    }).fetchForPool(selectedPoolAddress);
+  }, [onWithdraw, selectedPoolAddress, userWalletAddress]);
+
   useEffect(() => {
     if (!tokenRate || !estimatedWithdrawData) {
       setEstimateInProgress(true);
@@ -481,7 +491,7 @@ const Withdraw: FC<WithdrawOutProps> = ({ onWithdraw }) => {
         </SectionContainer>
         <Spacer size={20} />
         <div className="tf__flex-row-center-vh">
-          <Execute actionName="Withdraw" disabled={executeDisabled} onExecute={onExecute} onExecuted={onWithdraw} />
+          <Execute actionName="Withdraw" disabled={executeDisabled} onExecute={onExecute} onExecuted={onExecuted} />
         </div>
       </SectionContainer>
     </div>

--- a/packages/tempus-client_v2/src/providers/getUserShareTokenBalanceProvider.ts
+++ b/packages/tempus-client_v2/src/providers/getUserShareTokenBalanceProvider.ts
@@ -1,0 +1,19 @@
+import UserShareTokenBalanceProvider, { UserShareTokenBalanceProviderParams } from './userShareTokenBalanceProvider';
+
+// Key - User wallet address
+// Value - Provider instance
+const userShareTokenBalanceProviderMap = new Map<string, UserShareTokenBalanceProvider>();
+const getUserShareTokenBalanceProvider = (
+  params: UserShareTokenBalanceProviderParams,
+): UserShareTokenBalanceProvider => {
+  let userShareTokenBalanceProvider = userShareTokenBalanceProviderMap.get(params.userWalletAddress);
+  if (!userShareTokenBalanceProvider) {
+    userShareTokenBalanceProvider = new UserShareTokenBalanceProvider(params);
+
+    userShareTokenBalanceProviderMap.set(params.userWalletAddress, userShareTokenBalanceProvider);
+  }
+
+  return userShareTokenBalanceProvider;
+};
+
+export default getUserShareTokenBalanceProvider;

--- a/packages/tempus-client_v2/src/providers/poolShareBalanceProvider.ts
+++ b/packages/tempus-client_v2/src/providers/poolShareBalanceProvider.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'ethers';
 import getVaultService from '../services/getVaultService';
 import { dynamicPoolDataState } from '../state/PoolDataState';
-import getConfig, { getConfigForPoolId } from '../utils/getConfig';
+import getConfig, { getConfigForPoolWithId } from '../utils/getConfig';
 
 class PoolShareBalanceProvider {
   /**
@@ -46,7 +46,7 @@ class PoolShareBalanceProvider {
   };
 
   private async fetchPoolBalance(poolId: string) {
-    const poolConfig = getConfigForPoolId(poolId);
+    const poolConfig = getConfigForPoolWithId(poolId);
     const vaultService = getVaultService();
 
     let poolTokens: {

--- a/packages/tempus-client_v2/src/providers/userShareTokenBalanceProvider.tsx
+++ b/packages/tempus-client_v2/src/providers/userShareTokenBalanceProvider.tsx
@@ -1,10 +1,10 @@
 import { Contract } from 'ethers';
-import { TempusPool } from '../interfaces/TempusPool';
-import { dynamicPoolDataState } from '../state/PoolDataState';
 import { ERC20 } from '../abi/ERC20';
 import ERC20ABI from '../abi/ERC20.json';
-import getConfig, { getConfigForPoolWithAddress } from '../utils/getConfig';
+import { TempusPool } from '../interfaces/TempusPool';
+import { dynamicPoolDataState } from '../state/PoolDataState';
 import getDefaultProvider from '../services/getDefaultProvider';
+import getConfig, { getConfigForPoolWithAddress } from '../utils/getConfig';
 
 export interface UserShareTokenBalanceProviderParams {
   userWalletAddress: string;

--- a/packages/tempus-client_v2/src/providers/userShareTokenBalanceProvider.tsx
+++ b/packages/tempus-client_v2/src/providers/userShareTokenBalanceProvider.tsx
@@ -1,128 +1,93 @@
-import { useCallback, useContext, useEffect } from 'react';
-import { useState as useHookState } from '@hookstate/core';
-import { dynamicPoolDataState } from '../state/PoolDataState';
-import { WalletContext } from '../context/walletContext';
+import { Contract } from 'ethers';
 import { TempusPool } from '../interfaces/TempusPool';
-import getERC20TokenService from '../services/getERC20TokenService';
-import getConfig from '../utils/getConfig';
+import { dynamicPoolDataState } from '../state/PoolDataState';
+import { ERC20 } from '../abi/ERC20';
+import ERC20ABI from '../abi/ERC20.json';
+import getConfig, { getConfigForPoolWithAddress } from '../utils/getConfig';
+import getDefaultProvider from '../services/getDefaultProvider';
 
-const UserShareTokenBalanceProvider = () => {
-  const dynamicPoolData = useHookState(dynamicPoolDataState);
+export interface UserShareTokenBalanceProviderParams {
+  userWalletAddress: string;
+}
 
-  const { userWalletAddress, userWalletSigner } = useContext(WalletContext);
+class UserShareTokenBalanceProvider {
+  private userWalletAddress: string = '';
+  private tokenContracts: ERC20[] = [];
 
-  /**
-   * Fetch current principals balance for user.
-   */
-  const updatePrincipalsBalanceForPool = useCallback(
-    async (poolConfig: TempusPool) => {
-      if (userWalletSigner) {
-        const principalsService = getERC20TokenService(poolConfig.principalsAddress, userWalletSigner);
-        const balance = await principalsService.balanceOf(userWalletAddress);
+  constructor(params: UserShareTokenBalanceProviderParams) {
+    this.userWalletAddress = params.userWalletAddress;
+  }
 
-        const currentBalance = dynamicPoolData[poolConfig.address].userPrincipalsBalance.get();
-        // Only update state if fetched user principals balance is different from current user principals balance
-        if (!currentBalance || !currentBalance.eq(balance)) {
-          dynamicPoolData[poolConfig.address].userPrincipalsBalance.set(balance);
-        }
-      }
-    },
-    // TODO - We can now probably remove this provider components and update state directly from service classes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [userWalletSigner, userWalletAddress],
-  );
+  init() {
+    // Make sure to clean previous data before crating new subscriptions
+    this.destroy();
 
-  /**
-   * Fetch current yields balance for user.
-   */
-  const updateYieldsBalanceForPool = useCallback(
-    async (poolConfig: TempusPool) => {
-      if (userWalletSigner) {
-        const yieldsService = getERC20TokenService(poolConfig.yieldsAddress, userWalletSigner);
-        const balance = await yieldsService.balanceOf(userWalletAddress);
-
-        const currentBalance = dynamicPoolData[poolConfig.address].userYieldsBalance.get();
-        // Only update state if fetched user yields balance is different from current user yields balance
-        if (!currentBalance || !currentBalance.eq(balance)) {
-          dynamicPoolData[poolConfig.address].userYieldsBalance.set(balance);
-        }
-      }
-    },
-    // TODO - We can now probably remove this provider components and update state directly from service classes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [userWalletSigner, userWalletAddress],
-  );
-
-  const updatePrincipalsBalance = useCallback(async () => {
     getConfig().tempusPools.forEach(poolConfig => {
-      updatePrincipalsBalanceForPool(poolConfig);
-    });
-  }, [updatePrincipalsBalanceForPool]);
+      const tpsContract = new Contract(poolConfig.principalsAddress, ERC20ABI, getDefaultProvider()) as ERC20;
+      tpsContract.on(tpsContract.filters.Transfer(this.userWalletAddress, null), this.updatePrincipalsBalance);
+      tpsContract.on(tpsContract.filters.Transfer(null, this.userWalletAddress), this.updatePrincipalsBalance);
 
-  const updateYieldsBalance = useCallback(async () => {
-    getConfig().tempusPools.forEach(poolConfig => {
-      updateYieldsBalanceForPool(poolConfig);
+      const tysContract = new Contract(poolConfig.yieldsAddress, ERC20ABI, getDefaultProvider()) as ERC20;
+      tysContract.on(tysContract.filters.Transfer(this.userWalletAddress, null), this.updateYieldsBalance);
+      tysContract.on(tysContract.filters.Transfer(null, this.userWalletAddress), this.updateYieldsBalance);
+
+      this.tokenContracts.push(tpsContract, tysContract);
     });
-  }, [updateYieldsBalanceForPool]);
+
+    // Fetch initial balances on app load
+    this.updatePrincipalsBalance();
+    this.updateYieldsBalance();
+  }
+
+  destroy() {
+    this.tokenContracts.forEach(tokenContract => {
+      tokenContract.removeAllListeners();
+    });
+    this.tokenContracts = [];
+  }
 
   /**
-   * Subscribe to user principals token transfer event
+   * Manually trigger user balance update. Can be called after user action that affects user balance.
    */
-  useEffect(() => {
-    if (!userWalletSigner) {
-      return;
+  fetchForPool(address: string) {
+    const poolConfig = getConfigForPoolWithAddress(address);
+
+    this.updatePrincipalsBalanceForPool(poolConfig);
+    this.updateYieldsBalanceForPool(poolConfig);
+  }
+
+  private async updatePrincipalsBalanceForPool(poolConfig: TempusPool) {
+    const tpsContract = new Contract(poolConfig.principalsAddress, ERC20ABI, getDefaultProvider()) as ERC20;
+    const balance = await tpsContract.balanceOf(this.userWalletAddress);
+
+    const currentBalance = dynamicPoolDataState[poolConfig.address].userPrincipalsBalance.get();
+    // Only update state if fetched user principals balance is different from current user principals balance
+    if (!currentBalance || !currentBalance.eq(balance)) {
+      dynamicPoolDataState[poolConfig.address].userPrincipalsBalance.set(balance);
     }
+  }
 
-    getConfig().tempusPools.forEach(poolConfig => {
-      const principalsService = getERC20TokenService(poolConfig.principalsAddress, userWalletSigner);
+  private async updateYieldsBalanceForPool(poolConfig: TempusPool) {
+    const tysContract = new Contract(poolConfig.yieldsAddress, ERC20ABI, getDefaultProvider()) as ERC20;
+    const balance = await tysContract.balanceOf(this.userWalletAddress);
 
-      principalsService.onTransfer(userWalletAddress, null, updatePrincipalsBalance);
-      principalsService.onTransfer(null, userWalletAddress, updatePrincipalsBalance);
-    });
-
-    return () => {
-      getConfig().tempusPools.forEach(poolConfig => {
-        const principalsService = getERC20TokenService(poolConfig.principalsAddress, userWalletSigner);
-
-        principalsService.offTransfer(userWalletAddress, null, updatePrincipalsBalance);
-        principalsService.offTransfer(null, userWalletAddress, updatePrincipalsBalance);
-      });
-    };
-  }, [userWalletAddress, userWalletSigner, updatePrincipalsBalance]);
-
-  useEffect(() => {
-    updatePrincipalsBalance();
-    updateYieldsBalance();
-  }, [updatePrincipalsBalance, updateYieldsBalance]);
-
-  /**
-   * Subscribe to user yields token transfer event
-   */
-  useEffect(() => {
-    if (!userWalletSigner) {
-      return;
+    const currentBalance = dynamicPoolDataState[poolConfig.address].userYieldsBalance.get();
+    // Only update state if fetched user yields balance is different from current user yields balance
+    if (!currentBalance || !currentBalance.eq(balance)) {
+      dynamicPoolDataState[poolConfig.address].userYieldsBalance.set(balance);
     }
+  }
 
+  private updatePrincipalsBalance = () => {
     getConfig().tempusPools.forEach(poolConfig => {
-      const yieldsService = getERC20TokenService(poolConfig.yieldsAddress, userWalletSigner);
-
-      yieldsService.onTransfer(userWalletAddress, null, updateYieldsBalance);
-      yieldsService.onTransfer(null, userWalletAddress, updateYieldsBalance);
+      this.updatePrincipalsBalanceForPool(poolConfig);
     });
+  };
 
-    return () => {
-      getConfig().tempusPools.forEach(poolConfig => {
-        const yieldsService = getERC20TokenService(poolConfig.yieldsAddress, userWalletSigner);
-
-        yieldsService.offTransfer(userWalletAddress, null, updateYieldsBalance);
-        yieldsService.offTransfer(null, userWalletAddress, updateYieldsBalance);
-      });
-    };
-  }, [userWalletAddress, userWalletSigner, updateYieldsBalance]);
-
-  /**
-   * Provider component only updates context value when needed. It does not show anything in the UI.
-   */
-  return null;
-};
+  private updateYieldsBalance = () => {
+    getConfig().tempusPools.forEach(poolConfig => {
+      this.updateYieldsBalanceForPool(poolConfig);
+    });
+  };
+}
 export default UserShareTokenBalanceProvider;

--- a/packages/tempus-client_v2/src/utils/getConfig.ts
+++ b/packages/tempus-client_v2/src/utils/getConfig.ts
@@ -18,12 +18,23 @@ export default function getConfig(): Config {
   }
 }
 
-export function getConfigForPoolId(poolId: string): TempusPool {
+export function getConfigForPoolWithId(poolId: string): TempusPool {
   const poolConfig = getConfig().tempusPools.find(tempusPool => {
     return tempusPool.poolId === poolId;
   });
   if (!poolConfig) {
-    throw new Error(`Failed to get pool config with poolId ${poolId}`);
+    throw new Error(`Failed to get pool config with pool id ${poolId}`);
+  }
+
+  return poolConfig;
+}
+
+export function getConfigForPoolWithAddress(poolAddress: string): TempusPool {
+  const poolConfig = getConfig().tempusPools.find(tempusPool => {
+    return tempusPool.address === poolAddress;
+  });
+  if (!poolConfig) {
+    throw new Error(`Failed to get pool config with pool address ${poolAddress}`);
   }
 
   return poolConfig;


### PR DESCRIPTION
And manually trigger user share balance fetch after every action that affects user share balance. This will make sure we update user share balances across the UI as soon as action is executed, instead of waiting for transfer event to trigger, which can sometimes take a lot (~5-10 seconds).