### PR TITLE
Do not subscribe to block events if user does not have wallet connected

### DIFF
--- a/packages/tempus-client_v2/src/providers/fixedAPRProvider.tsx
+++ b/packages/tempus-client_v2/src/providers/fixedAPRProvider.tsx
@@ -96,16 +96,16 @@ const FixedAPRProvider = () => {
    * Update Fixed APR for all pools on each block.
    */
   useEffect(() => {
-    const provider = getProvider();
-    if (!provider) {
+    if (!userWalletSigner) {
       return;
     }
+    const provider = userWalletSigner.provider;
 
     provider.on('block', fetchAPR);
     return () => {
       provider.off('block', fetchAPR);
     };
-  }, [fetchAPR, getProvider]);
+  }, [fetchAPR, userWalletSigner]);
 
   /**
    * Provider component only updates context value when needed. It does not show anything in the UI.

--- a/packages/tempus-client_v2/src/providers/variableAPRProvider.tsx
+++ b/packages/tempus-client_v2/src/providers/variableAPRProvider.tsx
@@ -87,16 +87,16 @@ const VariableAPRProvider = () => {
    * Update APR for all pools on each block.
    */
   useEffect(() => {
-    const provider = getProvider();
-    if (!provider) {
+    if (!userWalletSigner) {
       return;
     }
+    const provider = userWalletSigner.provider;
 
     provider.on('block', fetchAPR);
     return () => {
       provider.off('block', fetchAPR);
     };
-  }, [fetchAPR, getProvider]);
+  }, [fetchAPR, userWalletSigner]);
 
   /**
    * Provider component only updates context value when needed. It does not show anything in the UI.


### PR DESCRIPTION
In case user did not connect the wallet, skip block event subscription.