### PR TITLE
show tooltip for LP APR breakdown, tooltip refactor

### DIFF
--- a/packages/tempus-client_v2/src/components/dashboard/dashboard.scss
+++ b/packages/tempus-client_v2/src/components/dashboard/dashboard.scss
@@ -187,6 +187,31 @@ $padding: 20px;
       .tf__dashboard__body__apy-value {
         display: flex;
         align-items: flex-end;
+
+        .tf__dashboard__body__apy-anchor {
+          cursor: pointer;
+          text-decoration: none;
+          background: inherit;
+          border: none;
+          padding: 0;
+          display: block;
+
+          &:hover {
+            border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+          }
+        }
+
+        .tc__infoTooltip {
+          .tc__infoTooltip-popup {
+            width: inherit;
+          }
+
+          .tc__infoTooltip-anchor.tc__infoTooltip-active {
+            .tf__dashboard__body__apy-anchor {
+              border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+            }
+          }
+        }
       }
     }
 

--- a/packages/tempus-client_v2/src/components/dashboard/headerSection/headerContent.tsx
+++ b/packages/tempus-client_v2/src/components/dashboard/headerSection/headerContent.tsx
@@ -17,7 +17,7 @@ const HeaderContent: FC<ContentProps> = props => {
             {props.children}
           </Typography>
           <div className="tf__dashboard__header-info-icon-container">
-            <InfoTooltip text={props.column.tooltip} />
+            <InfoTooltip content={props.column.tooltip} />
           </div>
         </>
       ) : (

--- a/packages/tempus-client_v2/src/components/dashboard/popups/variableAPRBreakDownTooltip.scss
+++ b/packages/tempus-client_v2/src/components/dashboard/popups/variableAPRBreakDownTooltip.scss
@@ -1,0 +1,34 @@
+.tc__apr-breakdown-tooptip__container {
+    width: 200px;
+    .tc__apr-breakdown-tooptip__section {
+        display: flex;
+        justify-content: space-between;
+        padding: 6px 8px;
+    }
+    .tc__apr-breakdown-tooptip__separator {
+        border-bottom: 2px solid rgba(0, 0, 0, 0.15);
+        margin: 6px 0;
+        &::before {
+            content: "";
+            width: 8px;
+            height: 8px;
+            border-bottom: 2px solid rgba(0, 0, 0, 0.15);
+            display: block;
+            position: absolute;
+            right: 50%;
+            transform: rotate(35deg) translateY(-6px);
+            background-color: #fcfcfc;
+        }
+        &::after {
+            content: "";
+            width: 8px;
+            height: 8px;
+            border-bottom: 2px solid rgba(0, 0, 0, 0.15);
+            display: block;
+            position: absolute;
+            left: 50%;
+            transform: rotate(-35deg) translateY(-6px);
+            background-color: #fcfcfc;
+        }
+    }
+}

--- a/packages/tempus-client_v2/src/components/dashboard/popups/variableAPRBreakDownTooltip.tsx
+++ b/packages/tempus-client_v2/src/components/dashboard/popups/variableAPRBreakDownTooltip.tsx
@@ -1,0 +1,56 @@
+import React, { FC, useContext, useMemo } from 'react';
+import { LanguageContext } from '../../../context/languageContext';
+import getText from '../../../localisation/getText';
+import NumberUtils from '../../../services/NumberUtils';
+import Typography from '../../typography/Typography';
+
+import './variableAPRBreakDownTooltip.scss';
+
+interface VariableAPRBreakDownTooltipProps {
+  protocolName: string;
+  apr: number;
+  tempusFees: number;
+}
+
+const VariableAPRBreakDownTooltip: FC<VariableAPRBreakDownTooltipProps> = props => {
+  const { protocolName, apr, tempusFees } = props;
+
+  const { language } = useContext(LanguageContext);
+
+  const protocolAPR = useMemo(() => NumberUtils.formatPercentage(apr - tempusFees, 2), [apr, tempusFees]);
+  const tempusAPR = useMemo(() => NumberUtils.formatPercentage(tempusFees, 2), [tempusFees]);
+  const combinedAPR = useMemo(() => NumberUtils.formatPercentage(apr, 2), [apr]);
+
+  // TODO: we need to add placeholder support for translation. issue #830. avoid string concat.
+  return (
+    <div className="tc__apr-breakdown-tooptip__container">
+      <div className="tc__apr-breakdown-tooptip__section">
+        <Typography color="default" variant="tooltip-card-text">
+          {protocolName} {getText('apr', language)}
+        </Typography>
+        <Typography color="default" variant="tooltip-card-text">
+          {protocolAPR}
+        </Typography>
+      </div>
+      <div className="tc__apr-breakdown-tooptip__section">
+        <Typography color="default" variant="tooltip-card-text">
+          {getText('tempus', language)} {getText('apr', language)}
+        </Typography>
+        <Typography color="default" variant="tooltip-card-text">
+          {tempusAPR}
+        </Typography>
+      </div>
+      <div className="tc__apr-breakdown-tooptip__separator"></div>
+      <div className="tc__apr-breakdown-tooptip__section">
+        <Typography color="default" variant="tooltip-card-text">
+          {getText('combinedApr', language)}
+        </Typography>
+        <Typography color="default" variant="tooltip-card-text">
+          {combinedAPR}
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+export default VariableAPRBreakDownTooltip;

--- a/packages/tempus-client_v2/src/components/deposit/Deposit.tsx
+++ b/packages/tempus-client_v2/src/components/deposit/Deposit.tsx
@@ -840,7 +840,7 @@ const Deposit: FC<DepositProps> = ({ narrow }) => {
                 <Spacer size={10} />
                 <Typography variant="yield-card-header">{getText('fixYourFutureYield', language)}</Typography>
                 <Spacer size={10} />
-                <InfoTooltip text={getText('interestRateProtectionTooltipText', language)} />
+                <InfoTooltip content={getText('interestRateProtectionTooltipText', language)} />
               </div>
               <div className="tc__deposit__yield-name-card">
                 <Typography variant="yield-card-type" color="primary">
@@ -930,7 +930,7 @@ const Deposit: FC<DepositProps> = ({ narrow }) => {
                 <Spacer size={10} />
                 <Typography variant="yield-card-header">{getText('provideLiquidity', language)}</Typography>
                 <Spacer size={10} />
-                <InfoTooltip text={getText('liquidityProvisionTooltipText', language)} />
+                <InfoTooltip content={getText('liquidityProvisionTooltipText', language)} />
               </div>
               <div className="tc__deposit__yield-name-card">
                 <Typography variant="yield-card-type" color="accent">

--- a/packages/tempus-client_v2/src/components/infoTooltip/infoTooltip.scss
+++ b/packages/tempus-client_v2/src/components/infoTooltip/infoTooltip.scss
@@ -1,28 +1,94 @@
 .tc__infoTooltip {
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .tc__infoTooltip__popper {
-  z-index: 999;
+    z-index: 999;
+    .tc__infoTooltip-arrow {
+        overflow: hidden;
+        position: absolute;
+        width: 20px;
+        height: 13px;
+        box-sizing: border-box;
+        &::before {
+            content: "";
+            margin: auto;
+            display: block;
+            width: 100%;
+            height: 100%;
+            box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+            border: 1px solid rgba(0, 0, 0, 0.2);
+            background-color: #fcfcfc;
+            transform: rotate(45deg);
+        }
+    }
+    &[x-placement*="bottom"] {
+        margin-top: 8px;
+        .tc__infoTooltip-arrow {
+            top: 0;
+            left: 0;
+            margin-top: -12px;
+            margin-left: 4px;
+            margin-right: 4px;
+            &::before {
+                transform-origin: 0 100%;
+            }
+        }
+    }
+    &[x-placement*="top"] {
+        margin-bottom: 8px;
+        .tc__infoTooltip-arrow {
+            bottom: 0;
+            left: 0;
+            margin-bottom: -12px;
+            margin-left: 4px;
+            margin-right: 4px;
+            &::before {
+                transform-origin: 100% 0;
+            }
+        }
+    }
+    &[x-placement*="right"] {
+        margin-left: 8px;
+        .tc__infoTooltip-arrow {
+            left: 0;
+            margin-left: -12px;
+            margin-left: 4px;
+            margin-right: 4px;
+            &::before {
+                transform-origin: 100% 100%;
+            }
+        }
+    }
+    &[x-placement*="left"] {
+        margin-right: 8px;
+        .tc__infoTooltip-arrow {
+            right: 0;
+            margin-right: -12px;
+            margin-left: 4px;
+            margin-right: 4px;
+            &::before {
+                transform-origin: 0 0;
+            }
+        }
+    }
 }
 
 .tc__infoTooltip-icon {
-  width: 20px;
-  height: 20px;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
 }
 
 .tc__infoTooltip-popup {
-  background: #fcfcfc;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  border-radius: 5px;
-  padding: 10px;
-  width: 350px;
-  z-index: 1;
-  cursor: default;
+    background: #fcfcfc;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border-radius: 5px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    padding: 10px;
+    width: 350px;
+    z-index: 1;
+    cursor: default;
 }

--- a/packages/tempus-client_v2/src/components/infoTooltip/infoTooltip.tsx
+++ b/packages/tempus-client_v2/src/components/infoTooltip/infoTooltip.tsx
@@ -1,42 +1,65 @@
 import { Popper } from '@material-ui/core';
-import React, { FC, useCallback, useRef, useState } from 'react';
+import React, { FC, ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import InfoIcon from '../icons/InfoIcon';
 import Typography from '../typography/Typography';
 
 import './infoTooltip.scss';
 
 interface InfoToolTipProps {
-  text: string;
+  content: string | ReactNode;
 }
 
 const InfoTooltip: FC<InfoToolTipProps> = props => {
-  const { text } = props;
-
-  const anchorRef = useRef<HTMLDivElement>(null);
+  const { content, children = <InfoIcon /> } = props;
 
   const [open, setOpen] = useState<boolean>(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const arrowRef = useRef<HTMLDivElement>(null);
 
   const toggle = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
 
     setOpen(prevState => !prevState);
   }, []);
-
-  return (
-    <div className="tc__infoTooltip">
+  const popupAnchor = useMemo(() => {
+    if (children) {
+      return (
+        <div onClick={toggle} ref={anchorRef}>
+          {children}
+        </div>
+      );
+    }
+    return (
       <div onClick={toggle} ref={anchorRef} className="tc__infoTooltip-icon">
         <InfoIcon />
       </div>
+    );
+  }, [children, toggle]);
+  const popupContent = useMemo(() => {
+    if (typeof content === 'string') {
+      return <Typography variant="tooltip-card-text" html={content} />;
+    }
+    return content;
+  }, [content]);
+
+  return (
+    <div className="tc__infoTooltip">
+      <div className={`tc__infoTooltip-anchor ${open ? 'tc__infoTooltip-active' : ''}`}>{popupAnchor}</div>
       <Popper
         className="tc__infoTooltip__popper"
         open={open}
         anchorEl={anchorRef.current}
         placement="bottom-start"
         disablePortal
+        modifiers={{
+          arrow: {
+            enabled: true,
+            element: arrowRef.current,
+          },
+        }}
       >
-        <div className="tc__infoTooltip-popup">
-          <Typography variant="tooltip-card-text" html={text} />
-        </div>
+        <div className="tc__infoTooltip-arrow" ref={arrowRef}></div>
+        <div className="tc__infoTooltip-popup">{popupContent}</div>
       </Popper>
       {open && <div className="tc__backdrop" onClick={toggle} />}
     </div>

--- a/packages/tempus-client_v2/src/components/navbar/Slippage.tsx
+++ b/packages/tempus-client_v2/src/components/navbar/Slippage.tsx
@@ -60,7 +60,7 @@ const Slippage = () => {
         <Spacer size={10} />
         <Typography variant="card-body-text">{getText('slippageTolerance', language)}</Typography>
         <div className="tc__header__settings-menu__section-header-action">
-          <InfoTooltip text={getText('slippageTooltip', language)} />
+          <InfoTooltip content={getText('slippageTooltip', language)} />
         </div>
       </div>
       <div className="tc__header__settings-menu__section-row">

--- a/packages/tempus-client_v2/src/components/sectionContainer/SectionContainer.tsx
+++ b/packages/tempus-client_v2/src/components/sectionContainer/SectionContainer.tsx
@@ -45,7 +45,7 @@ const SectionContainer: FC<SectionContainerProps> = props => {
       <div className="tf__dialog__section-title">
         {title && <Typography variant="card-title">{getText(title, language)}</Typography>}
         {title && <Spacer size={15} />}
-        {tooltip && <InfoTooltip text={tooltip} />}
+        {tooltip && <InfoTooltip content={tooltip} />}
       </div>
       {title && <Spacer size={15} />}
       <div className={contentClasses} onClick={onClick}>

--- a/packages/tempus-client_v2/src/localisation/en.ts
+++ b/packages/tempus-client_v2/src/localisation/en.ts
@@ -1,6 +1,7 @@
 import Words from './words';
 
 const en: { [word in Words]: string } = {
+  tempus: 'Tempus',
   max: 'max',
   min: 'min',
   dashboard: 'Dashboard',
@@ -156,5 +157,6 @@ const en: { [word in Words]: string } = {
   provideLiquidityDescription: 'Use your LP tokens to provide liquidity to the pool and earn rewards.',
   removeLiquidityDescription:
     'Remove your liquidity from the pool with the accrued rewards in the form of your initial LP tokens.',
+  combinedApr: 'Combined APR',
 };
 export default en;

--- a/packages/tempus-client_v2/src/localisation/es.ts
+++ b/packages/tempus-client_v2/src/localisation/es.ts
@@ -1,6 +1,7 @@
 import Words from './words';
 
 const es: { [word in Words]: string } = {
+  tempus: 'Tempus',
   max: 'max',
   min: 'min',
   dashboard: 'Panel de Control',
@@ -157,5 +158,6 @@ const es: { [word in Words]: string } = {
   provideLiquidityDescription: 'Use sus tokens LP para proporcionar liquidez al grupo y ganar recompensas.',
   removeLiquidityDescription:
     'Retire su liquidez del grupo con las recompensas acumuladas en forma de sus tokens LP iniciales.',
+  combinedApr: 'APR combinado',
 };
 export default es;

--- a/packages/tempus-client_v2/src/localisation/it.ts
+++ b/packages/tempus-client_v2/src/localisation/it.ts
@@ -1,6 +1,7 @@
 import Words from './words';
 
 const it: { [word in Words]: string } = {
+  tempus: 'Tempus',
   max: 'max',
   min: 'min',
   dashboard: 'Pannello',
@@ -158,5 +159,6 @@ const it: { [word in Words]: string } = {
   provideLiquidityDescription: 'Usa i tuoi LP token per immettere liquidità nella pool e guadagnare commissioni.',
   removeLiquidityDescription:
     'Rimuovi liquidità dalla pool insieme alle commissioni sotto forma degli LP token iniziali.',
+  combinedApr: 'APR combinato',
 };
 export default it;

--- a/packages/tempus-client_v2/src/localisation/words.ts
+++ b/packages/tempus-client_v2/src/localisation/words.ts
@@ -1,4 +1,5 @@
 type Words =
+  | 'tempus'
   | 'max'
   | 'min'
   | 'dashboard'
@@ -136,6 +137,7 @@ type Words =
   | 'mintDescription'
   | 'swapDescription'
   | 'provideLiquidityDescription'
-  | 'removeLiquidityDescription';
+  | 'removeLiquidityDescription'
+  | 'combinedApr';
 
 export default Words;

--- a/packages/tempus-client_v2/src/providers/variableAPRProvider.tsx
+++ b/packages/tempus-client_v2/src/providers/variableAPRProvider.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useContext, useEffect } from 'react';
+import { ethers } from 'ethers';
 import { useState as useHookState } from '@hookstate/core';
 import getDefaultProvider from '../services/getDefaultProvider';
 import getVariableRateService from '../services/getVariableRateService';
@@ -57,6 +58,7 @@ const VariableAPRProvider = () => {
           return {
             address: tempusPool.address,
             variableAPR: variableAPR,
+            tempusFees: Number(ethers.utils.formatEther(fees)),
           };
         }),
       );
@@ -72,6 +74,8 @@ const VariableAPRProvider = () => {
         if (!currentAPR || (fetchedAPRData.variableAPR && currentAPR !== fetchedAPRData.variableAPR)) {
           dynamicPoolData[fetchedAPRData.address].variableAPR.set(fetchedAPRData.variableAPR);
         }
+
+        dynamicPoolData[fetchedAPRData.address].tempusFees.set(fetchedAPRData.tempusFees);
       });
     } catch (error) {
       console.log('VariableAPRProvider - fetchAPR', error);

--- a/packages/tempus-client_v2/src/state/PoolDataState.ts
+++ b/packages/tempus-client_v2/src/state/PoolDataState.ts
@@ -39,6 +39,7 @@ export interface DynamicPoolData extends AvailableToDeposit {
   userYieldBearingTokenBalance: BigNumber | null;
   tvl: BigNumber | null;
   variableAPR: number | null;
+  tempusFees: number | null;
   fixedAPR: number | null | 'fetching';
   negativeYield: boolean;
 }
@@ -68,6 +69,7 @@ getConfig().tempusPools.forEach(tempusPoolConfig => {
     userYieldBearingTokenBalance: null,
     tvl: null,
     variableAPR: null,
+    tempusFees: null,
     fixedAPR: 'fetching',
     negativeYield: true,
   };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/85455/151263414-3e552c6e-4696-4ec7-897a-b13f857fdaf7.png)

- refactor `components/infoTooltip` to support customized anchor and React node as tooltip content (this should be an atomic components that will be reused by `feesTooltip` and `aprTooltip` as well, but it's out of scope of this task)
- show arrow for tooltip (we are using [material UI v4](https://v4.mui.com/components/popper/) which is using [Popper v1](https://popper.js.org/docs/v1/#modifiers..arrow). to make arrow working we need to implement the arrow CSS which can be referred [here](https://github.com/mui-org/material-ui/blob/4f2a07e140c954b478a6670c009c23a59ec3e2d4/docs/src/pages/components/popper/ScrollPlayground.js)
- `PoolDataState` to support `tempusFees`
- added translation