### PR TITLE
Fix Wallet infinite looping - closes #1017

### DIFF
--- a/packages/tempus-client_v2/src/components/wallet/Wallet.tsx
+++ b/packages/tempus-client_v2/src/components/wallet/Wallet.tsx
@@ -464,7 +464,7 @@ const Wallet = () => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, setWalletData, activate, setSelectedWallet, unsupportedNetwork]);
+  }, []);
 
   useEffect(() => {
     if (!active) {


### PR DESCRIPTION
The `useEffect` function that checks if either `MetaMask` or `WalletConnect` are installed is required to run only once