### PR TITLE
Use parseUnits when parsing LP token amount in execute disabled state logic

### DIFF
--- a/packages/tempus-client_v2/src/components/removeLiquidity/RemoveLiquidity.tsx
+++ b/packages/tempus-client_v2/src/components/removeLiquidity/RemoveLiquidity.tsx
@@ -209,10 +209,12 @@ const RemoveLiquidity: FC<RemoveLiquidityProps> = props => {
 
   const executeDisabled = useMemo(() => {
     const zeroAmount = isZeroString(amount);
-    const amountExceedsBalance = ethers.utils.parseEther(amount || '0').gt(userLPTokenBalance || BigNumber.from('0'));
+    const amountExceedsBalance = ethers.utils
+      .parseUnits(amount || '0', tokenPrecision.lpTokens)
+      .gt(userLPTokenBalance || BigNumber.from('0'));
 
     return !tokensApproved || zeroAmount || amountExceedsBalance || estimateInProgress;
-  }, [amount, userLPTokenBalance, tokensApproved, estimateInProgress]);
+  }, [amount, userLPTokenBalance, tokensApproved, estimateInProgress, tokenPrecision.lpTokens]);
 
   return (
     <div className="tc__removeLiquidity">


### PR DESCRIPTION
Currently this does not fix any issue because all pools have LP tokens set to 18 decimal points, but in future if we have pools with LP tokens that do not have 18 decimals app would break, this prevents that.