### PR TITLE
Fix storybook deploy branch regex filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
             - build-storybook
           filters:
             branches:
-              only: /(release-)/
+              only: /^lazar.*$/
       - deploy-to-stage:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
             - build-storybook
           filters:
             branches:
-              only: /^lazar.*$/
+              only: /^release-.*$/
       - deploy-to-stage:
           requires:
             - test


### PR DESCRIPTION
Regex needs to match whole branch name in order for CI to run the task.