### PR TITLE
replace Decimal on NumberInput

### DIFF
--- a/packages/tempus-client_v3/src/components/shared/BaseInput/BaseInput.stories.tsx
+++ b/packages/tempus-client_v3/src/components/shared/BaseInput/BaseInput.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory } from '@storybook/react';
 import { FC, useCallback, useState } from 'react';
 import BaseInput, { BaseInputProps } from './BaseInput';
+import Typography from '../Typography';
 
 export default {
   title: 'BaseInput',
@@ -18,8 +19,17 @@ const style = {
 
 const Wrapper: FC<BaseInputProps> = props => {
   const [value, setValue] = useState<string>(props.value ?? '');
+  const [debouncedValue, setDebouncedValue] = useState<string>('');
   const onChange = useCallback((val: string) => setValue(val), []);
-  return <BaseInput {...props} value={value} onChange={onChange} />;
+  const onDebounceChange = useCallback((val: string) => setDebouncedValue(val), []);
+  return (
+    <div>
+      <BaseInput {...props} value={value} onChange={onChange} onDebounceChange={onDebounceChange} />
+      <hr />
+      <Typography variant="body-secondary">onChange: {value}</Typography>
+      <Typography variant="body-secondary">onDebounceChange: {debouncedValue}</Typography>
+    </div>
+  );
 };
 
 const Template: ComponentStory<typeof BaseInput> = args => (
@@ -62,5 +72,4 @@ BaseInputDebounce.args = {
   pattern: '',
   disabled: false,
   debounce: true,
-  onDebounceChange: value => console.log(value),
 };

--- a/packages/tempus-client_v3/src/components/shared/CurrencyInput/CurrencyInput.tsx
+++ b/packages/tempus-client_v3/src/components/shared/CurrencyInput/CurrencyInput.tsx
@@ -61,12 +61,12 @@ const CurrencyInput: FC<CurrencyInputProps> = props => {
   const handlePercentageClick = useCallback(
     (percentage: number) => {
       const value = new Decimal(percentage).mul(maxAmount).div(100);
-      const formattedValue = value.toString();
+      const formattedValue = new Decimal(value.toTruncated(precision)).toString();
 
       handleValueChange(formattedValue);
       handleDebounceValueChange(formattedValue);
     },
-    [handleDebounceValueChange, handleValueChange, maxAmount],
+    [precision, handleDebounceValueChange, handleValueChange, maxAmount],
   );
 
   return (

--- a/packages/tempus-client_v3/src/components/shared/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/tempus-client_v3/src/components/shared/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -386,7 +386,7 @@ exports[`CurrencyInput updates the input field when a percentage button is click
   pattern="[0-9]*[.]?[0-9]{0,18}"
   placeholder="0"
   type="text"
-  value="25.0"
+  value="25"
 />
 `;
 
@@ -422,7 +422,7 @@ exports[`CurrencyInput updates the input field when a percentage button is click
   pattern="[0-9]*[.]?[0-9]{0,18}"
   placeholder="0"
   type="text"
-  value="50.0"
+  value="50"
 />
 `;
 
@@ -458,7 +458,7 @@ exports[`CurrencyInput updates the input field when a percentage button is click
   pattern="[0-9]*[.]?[0-9]{0,18}"
   placeholder="0"
   type="text"
-  value="75.0"
+  value="75"
 />
 `;
 
@@ -494,7 +494,7 @@ exports[`CurrencyInput updates the input field when a percentage button is click
   pattern="[0-9]*[.]?[0-9]{0,18}"
   placeholder="0"
   type="text"
-  value="100.0"
+  value="100"
 />
 `;
 

--- a/packages/tempus-client_v3/src/components/shared/NumberInput/NumberInput.spec.tsx
+++ b/packages/tempus-client_v3/src/components/shared/NumberInput/NumberInput.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import { BigNumber, utils } from 'ethers';
+import { Decimal } from 'tempus-core-services';
 import { FC, useState } from 'react';
 import NumberInput, { NumberInputProps } from './NumberInput';
 
@@ -79,8 +79,12 @@ describe('NumberInput', () => {
 
     fireEvent.click(button);
 
-    expect(mockOnChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, defaultProps.precision));
-    expect(mockOnDebounceChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, defaultProps.precision));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
+    expect(mockOnDebounceChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
   });
 
   it('click max button in number input with max as string will trigger onChange and onDebounceChange', () => {
@@ -97,12 +101,16 @@ describe('NumberInput', () => {
 
     fireEvent.click(button);
 
-    expect(mockOnChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, props.precision));
-    expect(mockOnDebounceChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, props.precision));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
+    expect(mockOnDebounceChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
   });
 
-  it('click max button in number input with max as BigNumber will trigger onChange and onDebounceChange', () => {
-    const props = { ...defaultProps, max: BigNumber.from(100) };
+  it('click max button in number input with max as Decimal will trigger onChange and onDebounceChange', () => {
+    const props = { ...defaultProps, max: new Decimal(100) };
     const { getByRole, queryByLabelText } = subject(props);
 
     const input = getByRole('textbox');
@@ -115,8 +123,30 @@ describe('NumberInput', () => {
 
     fireEvent.click(button);
 
-    expect(mockOnChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, props.precision));
-    expect(mockOnDebounceChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, props.precision));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
+    expect(mockOnDebounceChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
+  });
+
+  it('click max button in number input with precision 0 will show integer value of max', () => {
+    const props = { ...defaultProps, precision: 0 };
+    const { getByRole, queryByLabelText } = subject(props);
+
+    const input = getByRole('textbox');
+    const button = getByRole('button');
+    const label = queryByLabelText(defaultProps.label as string);
+
+    expect(input).not.toBeNull();
+    expect(button).not.toBeNull();
+    expect(label).not.toBeNull();
+
+    fireEvent.click(button);
+
+    expect(mockOnChange).toHaveBeenCalledWith(new Decimal(defaultProps.max).toTruncated());
+    expect(mockOnDebounceChange).toHaveBeenCalledWith(new Decimal(defaultProps.max).toTruncated());
   });
 
   it('click max button in number input without providing precision will use default precision', () => {
@@ -133,8 +163,10 @@ describe('NumberInput', () => {
 
     fireEvent.click(button);
 
-    expect(mockOnChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, 18));
-    expect(mockOnDebounceChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, 18));
+    expect(mockOnChange).toHaveBeenCalledWith(new Decimal(new Decimal(defaultProps.max).toTruncated(18)).toString());
+    expect(mockOnDebounceChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(18)).toString(),
+    );
   });
 
   it('click max button in number input with different precision will trigger onChange and onDebounceChange', () => {
@@ -151,8 +183,12 @@ describe('NumberInput', () => {
 
     fireEvent.click(button);
 
-    expect(mockOnChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, props.precision));
-    expect(mockOnDebounceChange).toHaveBeenCalledWith(utils.formatUnits(defaultProps.max, props.precision));
+    expect(mockOnChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
+    expect(mockOnDebounceChange).toHaveBeenCalledWith(
+      new Decimal(new Decimal(defaultProps.max).toTruncated(defaultProps.precision)).toString(),
+    );
   });
 
   it('type text with unmatch pattern in number input will not trigger onChange and onDebounceChange', () => {

--- a/packages/tempus-client_v3/src/components/shared/NumberInput/NumberInput.stories.tsx
+++ b/packages/tempus-client_v3/src/components/shared/NumberInput/NumberInput.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory } from '@storybook/react';
 import { FC, useCallback, useState } from 'react';
 import NumberInput, { NumberInputProps } from './NumberInput';
+import Typography from '../Typography';
 
 export default {
   title: 'NumberInput',
@@ -18,8 +19,17 @@ const style = {
 
 const Wrapper: FC<NumberInputProps> = props => {
   const [value, setValue] = useState<string>(props.value ?? '');
+  const [debouncedValue, setDebouncedValue] = useState<string>('');
   const onChange = useCallback((val: string) => setValue(val), []);
-  return <NumberInput {...props} value={value} onChange={onChange} />;
+  const onDebounceChange = useCallback((val: string) => setDebouncedValue(val), []);
+  return (
+    <div>
+      <NumberInput {...props} value={value} onChange={onChange} onDebounceChange={onDebounceChange} />
+      <hr />
+      <Typography variant="body-secondary">onChange: {value}</Typography>
+      <Typography variant="body-secondary">onDebounceChange: {debouncedValue}</Typography>
+    </div>
+  );
 };
 
 const Template: ComponentStory<typeof NumberInput> = args => (
@@ -32,7 +42,7 @@ export const NumberInputRaw = Template.bind({});
 NumberInputRaw.args = {
   placeholder: 'placeholder',
   max: 100,
-  precision: 0,
+  precision: 6,
   disabled: false,
   debounce: false,
 };
@@ -42,7 +52,7 @@ NumberInputNormal.args = {
   label: 'number input',
   placeholder: 'placeholder',
   max: 100,
-  precision: 0,
+  precision: 6,
   disabled: false,
   debounce: false,
 };
@@ -53,7 +63,7 @@ NumberInputCaption.args = {
   placeholder: 'placeholder',
   caption: 'caption here',
   max: 100,
-  precision: 0,
+  precision: 6,
   disabled: false,
   debounce: false,
 };
@@ -65,7 +75,7 @@ NumberInputError.args = {
   caption: 'caption here',
   error: 'error here',
   max: 100,
-  precision: 0,
+  precision: 6,
   disabled: false,
   debounce: false,
 };
@@ -76,7 +86,17 @@ NumberInputDisabled.args = {
   placeholder: 'placeholder',
   caption: 'caption here',
   max: 100,
-  precision: 0,
+  precision: 6,
   disabled: true,
   debounce: false,
+};
+
+export const NumberInputDebounce = Template.bind({});
+NumberInputDebounce.args = {
+  label: 'number debounce',
+  placeholder: 'placeholder',
+  max: 100,
+  precision: 6,
+  disabled: false,
+  debounce: true,
 };

--- a/packages/tempus-client_v3/src/components/shared/NumberInput/NumberInput.tsx
+++ b/packages/tempus-client_v3/src/components/shared/NumberInput/NumberInput.tsx
@@ -1,5 +1,5 @@
 import { FC, memo, useCallback, useMemo } from 'react';
-import { BigNumber, utils } from 'ethers';
+import { Decimal, Numberish } from 'tempus-core-services';
 import TextInput from '../TextInput';
 import ButtonWrapper from '../ButtonWrapper';
 import Typography from '../Typography';
@@ -9,7 +9,7 @@ import './NumberInput.scss';
 export interface NumberInputProps {
   label?: string;
   value?: string;
-  max: number | string | BigNumber;
+  max: Numberish;
   precision?: number;
   placeholder?: string;
   caption?: string;
@@ -36,9 +36,9 @@ const NumberInput: FC<NumberInputProps> = props => {
   } = props;
 
   const onMaxClick = useCallback(() => {
-    const formatedMax = utils.formatUnits(max, precision);
-    onChange?.(formatedMax);
-    onDebounceChange?.(formatedMax);
+    const formattedMax = new Decimal(new Decimal(max).toTruncated(precision)).toString();
+    onChange?.(formattedMax);
+    onDebounceChange?.(formattedMax);
   }, [max, precision, onChange, onDebounceChange]);
   const maxButton = useMemo(
     () => (
@@ -50,6 +50,7 @@ const NumberInput: FC<NumberInputProps> = props => {
     ),
     [disabled, onMaxClick],
   );
+  const pattern = useMemo(() => (precision > 0 ? `[0-9,]*[.]?[0-9]{0,${precision}}` : '[0-9,]*'), [precision]);
 
   return (
     <div className="tc__number-input">
@@ -57,7 +58,7 @@ const NumberInput: FC<NumberInputProps> = props => {
         label={label}
         value={value}
         placeholder={placeholder}
-        pattern="[0-9,]*[.]?[0-9]*"
+        pattern={pattern}
         caption={caption}
         error={error}
         disabled={disabled}

--- a/packages/tempus-client_v3/src/components/shared/NumberInput/__snapshots__/NumberInput.spec.tsx.snap
+++ b/packages/tempus-client_v3/src/components/shared/NumberInput/__snapshots__/NumberInput.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`NumberInput renders a disabled number input 1`] = `
           class="tc__base-input"
           disabled=""
           id="text-input-2"
-          pattern="[0-9,]*[.]?[0-9]*"
+          pattern="[0-9,]*[.]?[0-9]{0,18}"
           placeholder="number input placeholder"
           type="text"
           value=""
@@ -76,7 +76,7 @@ exports[`NumberInput renders a number input with label, value and caption 1`] = 
         <input
           class="tc__base-input"
           id="text-input-1"
-          pattern="[0-9,]*[.]?[0-9]*"
+          pattern="[0-9,]*[.]?[0-9]{0,18}"
           placeholder="number input placeholder"
           type="text"
           value="value"

--- a/packages/tempus-client_v3/src/components/shared/TextInput/TextInput.stories.tsx
+++ b/packages/tempus-client_v3/src/components/shared/TextInput/TextInput.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentStory } from '@storybook/react';
 import { FC, useCallback, useState } from 'react';
 import TextInput, { TextInputProps } from './TextInput';
 import Logo from '../Logo';
+import Typography from '../Typography';
 
 export default {
   title: 'TextInput',
@@ -19,8 +20,17 @@ const style = {
 
 const Wrapper: FC<TextInputProps> = props => {
   const [value, setValue] = useState<string>(props.value ?? '');
+  const [debouncedValue, setDebouncedValue] = useState<string>('');
   const onChange = useCallback((val: string) => setValue(val), []);
-  return <TextInput {...props} value={value} onChange={onChange} />;
+  const onDebounceChange = useCallback((val: string) => setDebouncedValue(val), []);
+  return (
+    <div>
+      <TextInput {...props} value={value} onChange={onChange} onDebounceChange={onDebounceChange} />
+      <hr />
+      <Typography variant="body-secondary">onChange: {value}</Typography>
+      <Typography variant="body-secondary">onDebounceChange: {debouncedValue}</Typography>
+    </div>
+  );
 };
 
 const Template: ComponentStory<typeof TextInput> = args => (
@@ -83,6 +93,18 @@ TextInputDisabled.args = {
   caption: 'caption here',
   disabled: true,
   debounce: false,
+  startAdornment: null,
+  endAdornment: null,
+};
+
+export const TextInputDebounce = Template.bind({});
+TextInputDebounce.args = {
+  label: 'text input',
+  placeholder: 'placeholder',
+  pattern: '',
+  caption: 'caption here',
+  disabled: false,
+  debounce: true,
   startAdornment: null,
   endAdornment: null,
 };

--- a/packages/tempus-core-services/src/datastructures/Decimal.spec.ts
+++ b/packages/tempus-core-services/src/datastructures/Decimal.spec.ts
@@ -478,7 +478,7 @@ describe('Decimal', () => {
       },
       {
         value: 123123,
-        expected: '123123.0',
+        expected: '123123',
       },
       {
         value: 789.789,
@@ -486,7 +486,7 @@ describe('Decimal', () => {
       },
       {
         value: 789789,
-        expected: '789789.0',
+        expected: '789789',
       },
       {
         value: 0.123789,
@@ -498,7 +498,7 @@ describe('Decimal', () => {
       },
       {
         value: -123123,
-        expected: '-123123.0',
+        expected: '-123123',
       },
       {
         value: -789.789,
@@ -506,7 +506,7 @@ describe('Decimal', () => {
       },
       {
         value: -789789,
-        expected: '-789789.0',
+        expected: '-789789',
       },
       {
         value: -0.123789,

--- a/packages/tempus-core-services/src/datastructures/Decimal.ts
+++ b/packages/tempus-core-services/src/datastructures/Decimal.ts
@@ -96,12 +96,12 @@ export default class Decimal {
   }
 
   toString(): string {
-    return utils.formatUnits(this.value, this.precision);
+    return utils.formatUnits(this.value, this.precision).replace(/\.0*$/, '');
   }
 
   toRounded(fractionDigits: number = 0): string {
     const str = this.toString();
-    const [integral, fraction] = str.split('.');
+    const [integral, fraction = ''] = str.split('.');
 
     const lastDigit = fraction.charAt(fractionDigits);
 
@@ -144,7 +144,7 @@ export default class Decimal {
 
   toTruncated(fractionDigits: number = 0): string {
     const str = this.toString();
-    const [integral, fraction] = str.split('.');
+    const [integral, fraction = ''] = str.split('.');
 
     if (fractionDigits > 0) {
       return `${integral}.${fraction.slice(0, fractionDigits).padEnd(fractionDigits, '0')}`;


### PR DESCRIPTION
- apply `Decimal` on `NumberInput`
- clicking MAX button should show `100` instead of `100.000000` in input box
- string form `toString()` or `Decimal` should not end with `.0` if it's an integer (i.e. `123` should be `123`, not `123.0`)
- `NumberInput` should honor `precision` from `props` to limit input pattern (i.e. pass in `precision` as `6` should limit user to type 6 decimal places only
- enhance storybook to show the effect of `onDebounceChange`