### PR TITLE
refactor Logo and Icon

### DIFF
--- a/packages/tempus-client_v3/src/components/shared/Icon/Checkmark.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Checkmark.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Checkmark: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Checkmark: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-checkmark"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/CheckmarkBordered.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/CheckmarkBordered.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const CheckmarkBordered: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const CheckmarkBordered: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-checkmark-bordered"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/CheckmarkRound.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/CheckmarkRound.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const CheckmarkRound: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const CheckmarkRound: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-checkmark-round"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/CheckmarkSolid.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/CheckmarkSolid.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const CheckmarkSolid: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT }) => (
+const CheckmarkSolid: FC<InnerIconProps> = ({ size }) => (
   <svg
     className="tc__icon tc__icon-checkmark-solid"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Close.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Close.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Close: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Close: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-close"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/CrossRound.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/CrossRound.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const CrossRound: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const CrossRound: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-cross-round"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Dark.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Dark.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Dark: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Dark: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-dark"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Discord.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Discord.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Discord: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Discord: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-discord"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/DownArrow.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/DownArrow.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const DownArrow: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const DownArrow: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-down-arrow"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/DownArrowThin.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/DownArrowThin.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const DownArrowThin: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const DownArrowThin: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-down-arrow-thin"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/DownChevron.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/DownChevron.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const DownChevron: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const DownChevron: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-down-chevron"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Exclamation.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Exclamation.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Exclamation: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Exclamation: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-exclamation"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/ExclamationBordered.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/ExclamationBordered.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const ExclamationBordered: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const ExclamationBordered: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-exclamation-bordered"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/ExclamationError.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/ExclamationError.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const ExclamationError: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT }) => (
+const ExclamationError: FC<InnerIconProps> = ({ size }) => (
   <svg
     className="tc__icon tc__icon-exclamation-error"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/ExclamationNeutral.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/ExclamationNeutral.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const ExclamationNeutral: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT }) => (
+const ExclamationNeutral: FC<InnerIconProps> = ({ size }) => (
   <svg
     className="tc__icon tc__icon-exclamation-neutral"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/External.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/External.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const External: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const External: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-external"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Github.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Github.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Github: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Github: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-github"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Globe.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Globe.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Globe: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Globe: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-globe"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/GridView.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/GridView.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const GridView: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const GridView: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-grid-view"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/IconProps.d.ts
+++ b/packages/tempus-client_v3/src/components/shared/Icon/IconProps.d.ts
@@ -2,3 +2,5 @@ export default interface IconProps {
   size?: 'large' | 'medium' | 'small' | 'tiny' | number;
   color?: string;
 }
+
+export interface InnerIconProps extends Required<IconProps> {}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Info.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Info.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Info: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Info: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-info"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/InfoBordered.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/InfoBordered.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const IconBordered: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const IconBordered: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-info-bordered"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/InfoSolid.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/InfoSolid.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const InfoSolid: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT }) => (
+const InfoSolid: FC<InnerIconProps> = ({ size }) => (
   <svg
     className="tc__icon tc__icon-info-solid"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/LeftArrow.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/LeftArrow.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const LeftArrow: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const LeftArrow: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-left-arrow"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/LeftArrowThin.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/LeftArrowThin.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const LeftArrowThin: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const LeftArrowThin: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-left-arrow-thin"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/LeftChevron.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/LeftChevron.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const LeftChevron: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const LeftChevron: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-left-chevron"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/ListView.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/ListView.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const ListView: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const ListView: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-list-view"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Medium.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Medium.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Medium: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Medium: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-medium"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Menu.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Menu.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Menu: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Menu: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-menu"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Minus.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Minus.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Minus: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Minus: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-minus"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/MinusRound.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/MinusRound.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const MinusRound: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const MinusRound: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-minus-round"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Plus.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Plus.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Plus: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Plus: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-plus"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/PlusRound.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/PlusRound.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const PlusRound: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const PlusRound: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-plus-round"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/RightArrow.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/RightArrow.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const RightArrow: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const RightArrow: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-right-arrow"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/RightArrowThin.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/RightArrowThin.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const RightArrowThin: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const RightArrowThin: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-right-arrow-thin"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/RightChevron.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/RightChevron.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const RightChevron: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const RightChevron: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-right-chevron"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Scroll.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Scroll.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Scroll: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Scroll: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-scroll"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Slippage.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Slippage.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Slippage: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Slippage: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-slippage"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Telegram.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Telegram.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Telegram: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Telegram: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-telegram"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/Twitter.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/Twitter.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const Twitter: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const Twitter: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-twitter"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/UpArrow.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/UpArrow.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const UpArrow: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const UpArrow: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-up-arrow"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/UpArrowThin.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/UpArrowThin.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const UpArrowThin: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const UpArrowThin: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-up-arrow-thin"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/UpChevron.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/UpChevron.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import IconProps from './IconProps';
-import { ICON_COLOR_DEFAULT, ICON_SIZE_DEFAULT } from './IconConstants';
+import { InnerIconProps } from './IconProps';
 import withIcon from './withIcon';
 
-const UpChevron: FC<IconProps> = ({ size = ICON_SIZE_DEFAULT, color = ICON_COLOR_DEFAULT }) => (
+const UpChevron: FC<InnerIconProps> = ({ size, color }) => (
   <svg
     className="tc__icon tc__icon-up-chevron"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Icon/withIcon.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Icon/withIcon.tsx
@@ -1,8 +1,15 @@
 import React, { FC, memo } from 'react';
-import IconProps from './IconProps';
-import { ICON_SIZE_DEFAULT, ICON_SIZE_LARGE, ICON_SIZE_MEDIUM, ICON_SIZE_SMALL, ICON_SIZE_TINY } from './IconConstants';
+import IconProps, { InnerIconProps } from './IconProps';
+import {
+  ICON_COLOR_DEFAULT,
+  ICON_SIZE_DEFAULT,
+  ICON_SIZE_LARGE,
+  ICON_SIZE_MEDIUM,
+  ICON_SIZE_SMALL,
+  ICON_SIZE_TINY,
+} from './IconConstants';
 
-const withIcon = (Component: React.ComponentType<IconProps>): FC<IconProps> =>
+const withIcon = (Component: React.ComponentType<InnerIconProps>): FC<IconProps> =>
   memo(({ size, color }) => {
     let actualSize = size;
     switch (size) {
@@ -18,12 +25,9 @@ const withIcon = (Component: React.ComponentType<IconProps>): FC<IconProps> =>
       case 'tiny':
         actualSize = ICON_SIZE_TINY;
         break;
-      case undefined:
-        actualSize = ICON_SIZE_DEFAULT;
-        break;
       default:
     }
-    return <Component size={actualSize} color={color} />;
+    return <Component size={actualSize ?? ICON_SIZE_DEFAULT} color={color ?? ICON_COLOR_DEFAULT} />;
   });
 
 export default withIcon;

--- a/packages/tempus-client_v3/src/components/shared/Logo/Logo.spec.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/Logo.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
-import Logo, { LogoProps, LogoType } from './Logo';
+import Logo, { LogoType } from './Logo';
+import LogoProps from './LogoProps';
 
 const defaultProps: LogoProps = {};
 

--- a/packages/tempus-client_v3/src/components/shared/Logo/LogoProps.d.ts
+++ b/packages/tempus-client_v3/src/components/shared/Logo/LogoProps.d.ts
@@ -1,3 +1,5 @@
 export default interface LogoProps {
   size?: 'large' | 'medium' | 'small' | number;
 }
+
+export interface InnerLogoProps extends Required<LogoProps> {}

--- a/packages/tempus-client_v3/src/components/shared/Logo/ProtocolAave.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/ProtocolAave.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const ProtocolAave: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const ProtocolAave: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-protocol-Aave"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/ProtocolLido.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/ProtocolLido.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const ProtocolLido: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const ProtocolLido: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-protocol-Lido"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/ProtocolRari.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/ProtocolRari.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const ProtocolRari: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const ProtocolRari: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-protocol-Rari"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenDAI.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenDAI.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenDAI: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenDAI: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-DAI"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenETH.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenETH.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenETH: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenETH: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-ETH"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenETHLight.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenETHLight.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenETHLight: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenETHLight: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-ETH-light"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenFTM.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenFTM.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenFTM: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenFTM: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-FTM"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenMIM.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenMIM.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenMIM: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenMIM: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-MIM"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenRARI.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenRARI.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenRARI: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenRARI: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-RARI"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenStETH.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenStETH.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenStETH: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenStETH: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-stETH"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenUSDC.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenUSDC.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenUSDC: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenUSDC: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-USDC"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenUSDT.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenUSDT.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenUSDT: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenUSDT: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-USDT"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenWBTC.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenWBTC.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenWBTC: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenWBTC: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-wBTC"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenWBTCDark.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenWBTCDark.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenWBTCDark: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenWBTCDark: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-wBTC-dark"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenWETH.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenWETH.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenWETH: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenWETH: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-wETH"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenWFTM.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenWFTM.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenWFTM: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenWFTM: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-wFTM"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenYFI.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenYFI.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenYFI: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenYFI: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-YFI"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenYvBTC.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenYvBTC.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenYvBTC: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenYvBTC: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-yvBTC"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenYvDAI.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenYvDAI.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenYvDAI: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenYvDAI: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-yvDAI"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenYvUSDC.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenYvUSDC.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenYvUSDC: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenYvUSDC: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-yvUSDC"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenYvUSDT.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenYvUSDT.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenYvUSDT: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenYvUSDT: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-yvUSDT"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenYvYFI.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenYvYFI.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenYvYFI: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenYvYFI: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-yvYFI"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/TokenYvwETH.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/TokenYvwETH.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const TokenYvwETH: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const TokenYvwETH: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-token-yvwETH"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/WalletGnosis.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/WalletGnosis.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const WalletGnosis: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const WalletGnosis: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-wallet-gnosis"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/WalletMetamask.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/WalletMetamask.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const WalletMetamask: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const WalletMetamask: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-wallet-metamask"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/WalletWalletConnect.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/WalletWalletConnect.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
-import LogoProps from './LogoProps';
-import { LOGO_SIZE_DEFAULT } from './LogoConstants';
+import { InnerLogoProps } from './LogoProps';
 import withLogo from './withLogo';
 
-const WalletWalletConnect: FC<LogoProps> = ({ size = LOGO_SIZE_DEFAULT }) => (
+const WalletWalletConnect: FC<InnerLogoProps> = ({ size }) => (
   <svg
     className="tc__logo tc__logo-wallet-walletconnect"
     width={size}

--- a/packages/tempus-client_v3/src/components/shared/Logo/withLogo.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Logo/withLogo.tsx
@@ -1,8 +1,8 @@
 import React, { FC, memo } from 'react';
-import LogoProps from './LogoProps';
+import LogoProps, { InnerLogoProps } from './LogoProps';
 import { LOGO_SIZE_DEFAULT, LOGO_SIZE_LARGE, LOGO_SIZE_MEDIUM, LOGO_SIZE_SMALL } from './LogoConstants';
 
-const withLogo = (Component: React.ComponentType<LogoProps>): FC<LogoProps> =>
+const withLogo = (Component: React.ComponentType<InnerLogoProps>): FC<LogoProps> =>
   memo(({ size }) => {
     let actualSize = size;
     switch (size) {
@@ -15,12 +15,9 @@ const withLogo = (Component: React.ComponentType<LogoProps>): FC<LogoProps> =>
       case 'small':
         actualSize = LOGO_SIZE_SMALL;
         break;
-      case undefined:
-        actualSize = LOGO_SIZE_DEFAULT;
-        break;
       default:
     }
-    return <Component size={actualSize} />;
+    return <Component size={actualSize ?? LOGO_SIZE_DEFAULT} />;
   });
 
 export default withLogo;


### PR DESCRIPTION
- back to 100% test coverage for `Logo` and `Icon`
- introduce `InnerLogoProps` and `InnerIconProps` for the original `Logo` or `Icon` which is a required version of `LogoProps` or `IconProps`
- remove unused default values, and handle the values in `withIcon` or `withLogo`
- move `IconProps.ts` and `LogoProps.ts` to `IconProps.d.ts` and `LogoProps.d.ts` (former one will be covered by test with 0%, latter one will be skipped)