### PR TITLE
Support different sizes and styles of modal

### DIFF
--- a/packages/tempus-client_v3/src/components/shared/Colors/colors.json
+++ b/packages/tempus-client_v3/src/components/shared/Colors/colors.json
@@ -54,6 +54,7 @@
   "formattedDateSeparatorHighContrast": "#7A7A7A",
 
   "modalBackground": "#FFFFFF",
+  "modalBackgroundShade": "#F3F7F9",
   "modalBorder": "#BFC0C0",
   "modalBackdrop": "#00000080",
 

--- a/packages/tempus-client_v3/src/components/shared/Modal/Modal.scss
+++ b/packages/tempus-client_v3/src/components/shared/Modal/Modal.scss
@@ -25,9 +25,38 @@
   position: relative;
   border: 1px solid var(--modalBorder);
   border-radius: 12px;
-  background-color: var(--modalBackground);
-  padding: 16px;
   pointer-events: all;
+
+  &.tc__modal__plain {
+    background-color: var(--modalBackground);
+  }
+
+  &.tc__modal__styled {
+    background: linear-gradient(0deg, var(--modalBackgroundShade) -0.55%, var(--modalBackground) 100%);
+  }
+}
+
+.tc__modal__size-small {
+  padding: 16px;
+
+  .tc__modal-header {
+    margin-bottom: 16px;
+  }
+}
+
+.tc__modal__size-large {
+  .tc__modal-header {
+    height: 40px;
+    padding: 0 16px;
+
+    .tc__icon-close {
+      margin-top: 16px;
+    }
+  }
+
+  .tc__modal__body {
+    padding: 0 40px 40px 40px;
+  }
 }
 
 .tc__modal-header {
@@ -35,5 +64,5 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  margin-bottom: 16px;
+  box-sizing: border-box;
 }

--- a/packages/tempus-client_v3/src/components/shared/Modal/Modal.spec.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Modal/Modal.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import Modal, { ModalProps } from './Modal';
+import Modal, { ModalProps, ModalStyleProps } from './Modal';
 
 const mockOnCloseHandler = jest.fn();
 
@@ -10,11 +10,21 @@ const defaultProps: ModalProps = {
 
 const modalContentText = 'This is modal content.';
 
-const subject = (props: ModalProps) => render(<Modal {...props}>{modalContentText}</Modal>);
+const subject = (props: ModalProps & ModalStyleProps) => render(<Modal {...props}>{modalContentText}</Modal>);
 
 describe('Modal', () => {
-  it('renders child elements when modal is open', () => {
-    const { container, getByText } = subject(defaultProps);
+  it('renders child elements when small modal is open', () => {
+    const { container, getByText } = subject({ ...defaultProps, size: 'small' });
+
+    const modalContent = getByText(modalContentText);
+
+    expect(modalContent).not.toBeNull();
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders child elements when large modal is open', () => {
+    const { container, getByText } = subject({ ...defaultProps, size: 'large' });
 
     const modalContent = getByText(modalContentText);
 

--- a/packages/tempus-client_v3/src/components/shared/Modal/Modal.tsx
+++ b/packages/tempus-client_v3/src/components/shared/Modal/Modal.tsx
@@ -5,14 +5,22 @@ import Typography from '../Typography';
 
 import './Modal.scss';
 
+type ModalVariant = 'plain' | 'styled';
+type ModalSize = 'small' | 'large';
+
 export interface ModalProps {
   open: boolean;
   onClose: () => void;
   title?: string;
 }
 
-const Modal: FC<ModalProps> = props => {
-  const { title = '', open, onClose, children } = props;
+interface ModalStyleProps {
+  variant?: ModalVariant;
+  size?: ModalSize;
+}
+
+const Modal: FC<ModalProps & ModalStyleProps> = props => {
+  const { title = '', open, onClose, variant = 'plain', size = 'small', children } = props;
 
   const onBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -32,20 +40,19 @@ const Modal: FC<ModalProps> = props => {
     <>
       <div id="modal-backdrop" className="tc__modal-backdrop" onClick={onBackdropClick} />
       <div className="tc__modal-container">
-        <div className="tc__modal">
+        <div className={`tc__modal tc__modal__${variant} tc__modal__size-${size}`}>
           <div className="tc__modal-header">
             <Typography variant="body-primary" weight="bold">
               {title}
             </Typography>
             <ButtonWrapper onClick={onCloseButtonClick}>
-              <Icon variant="close" size={20} />
+              <Icon variant="close" size={size === 'small' ? 'small' : 20} />
             </ButtonWrapper>
           </div>
-
-          {children}
+          <div className="tc__modal__body">{children}</div>
         </div>
       </div>
     </>
   );
 };
-export default React.memo(Modal) as FC<ModalProps>;
+export default React.memo(Modal) as FC<ModalProps & ModalStyleProps>;

--- a/packages/tempus-client_v3/src/components/shared/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/packages/tempus-client_v3/src/components/shared/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`Modal calls onClose when user clicks on backdrop 1`] = `
     class="tc__modal-container"
   >
     <div
-      class="tc__modal"
+      class="tc__modal tc__modal__plain tc__modal__size-small"
     >
       <div
         class="tc__modal-header"
@@ -26,9 +26,9 @@ exports[`Modal calls onClose when user clicks on backdrop 1`] = `
           <svg
             class="tc__icon tc__icon-close"
             fill="none"
-            height="20"
+            height="16"
             viewBox="0 0 16 16"
-            width="20"
+            width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -38,7 +38,11 @@ exports[`Modal calls onClose when user clicks on backdrop 1`] = `
           </svg>
         </button>
       </div>
-      This is modal content.
+      <div
+        class="tc__modal__body"
+      >
+        This is modal content.
+      </div>
     </div>
   </div>
 </div>
@@ -53,9 +57,9 @@ exports[`Modal calls onClose when user clicks on the close button 1`] = `
   <svg
     class="tc__icon tc__icon-close"
     fill="none"
-    height="20"
+    height="16"
     viewBox="0 0 16 16"
-    width="20"
+    width="16"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
@@ -68,7 +72,7 @@ exports[`Modal calls onClose when user clicks on the close button 1`] = `
 
 exports[`Modal does not render child elements when modal is closed 1`] = `<div />`;
 
-exports[`Modal renders child elements when modal is open 1`] = `
+exports[`Modal renders child elements when large modal is open 1`] = `
 <div>
   <div
     class="tc__modal-backdrop"
@@ -78,7 +82,7 @@ exports[`Modal renders child elements when modal is open 1`] = `
     class="tc__modal-container"
   >
     <div
-      class="tc__modal"
+      class="tc__modal tc__modal__plain tc__modal__size-large"
     >
       <div
         class="tc__modal-header"
@@ -106,7 +110,59 @@ exports[`Modal renders child elements when modal is open 1`] = `
           </svg>
         </button>
       </div>
-      This is modal content.
+      <div
+        class="tc__modal__body"
+      >
+        This is modal content.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Modal renders child elements when small modal is open 1`] = `
+<div>
+  <div
+    class="tc__modal-backdrop"
+    id="modal-backdrop"
+  />
+  <div
+    class="tc__modal-container"
+  >
+    <div
+      class="tc__modal tc__modal__plain tc__modal__size-small"
+    >
+      <div
+        class="tc__modal-header"
+      >
+        <div
+          style="font-style: normal; font-size: 16px; line-height: 24px; color: rgb(34, 34, 34); font-weight: 700; font-family: 'DM Sans', sans-serif; opacity: 1;"
+        />
+        <button
+          class="tc__btn "
+          data-selected="false"
+          type="button"
+        >
+          <svg
+            class="tc__icon tc__icon-close"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15.6081 13.7161C15.859 13.967 16 14.3073 16 14.6621C16 15.017 15.859 15.3572 15.6081 15.6081C15.3572 15.859 15.017 16 14.6621 16C14.3073 16 13.967 15.859 13.7161 15.6081L8 9.87872L2.2839 15.6081C2.033 15.859 1.6927 16 1.33788 16C0.98305 16 0.642756 15.859 0.391855 15.6081C0.140955 15.3572 0 15.017 0 14.6621C0 14.3073 0.140955 13.967 0.391855 13.7161L6.12128 8L0.391855 2.2839C0.140955 2.033 -2.64367e-09 1.6927 0 1.33788C2.64367e-09 0.98305 0.140955 0.642756 0.391855 0.391855C0.642756 0.140955 0.98305 2.64367e-09 1.33788 0C1.6927 -2.64367e-09 2.033 0.140955 2.2839 0.391855L8 6.12128L13.7161 0.391855C13.967 0.140955 14.3073 0 14.6621 0C15.017 0 15.3572 0.140955 15.6081 0.391855C15.859 0.642756 16 0.98305 16 1.33788C16 1.6927 15.859 2.033 15.6081 2.2839L9.87872 8L15.6081 13.7161Z"
+              fill="#222222"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="tc__modal__body"
+      >
+        This is modal content.
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
It introduces a `large` modal that has larger margins and a smaller header and a `styled` variant that has the gradient background instead of the solid one. Example of `large` & `styled` modal:

<img width="607" alt="image" src="https://user-images.githubusercontent.com/8989109/165911059-e8523592-dc3e-4d53-a59c-66392ab92831.png">
