### PR TITLE
improve preformance for useFixedAprs

### DIFF
--- a/packages/tempus-client_v3/src/constants.ts
+++ b/packages/tempus-client_v3/src/constants.ts
@@ -1,0 +1,2 @@
+export const POLLING_INTERVAL_IN_MS = 2 * 60 * 1000;
+export const DEBOUNCE_IN_MS = 500;

--- a/packages/tempus-client_v3/src/hooks/useAppEvent.ts
+++ b/packages/tempus-client_v3/src/hooks/useAppEvent.ts
@@ -1,0 +1,10 @@
+import { map, Observable } from 'rxjs';
+import { TempusPool } from 'tempus-core-services';
+import { poolList$ } from './usePoolList';
+
+// TODO: we dont have this event$ yet. this is a dummy event$ that gives tempusPool as param
+export const appEvent$: Observable<{ tempusPool: TempusPool }> = poolList$.pipe(
+  map(tempusPools => ({ tempusPool: tempusPools[0] })),
+);
+
+// TODO: we should have a hook for consumer to emit app event like deposit/withdraw

--- a/packages/tempus-client_v3/src/hooks/useFixedAprs.spec.ts
+++ b/packages/tempus-client_v3/src/hooks/useFixedAprs.spec.ts
@@ -1,13 +1,18 @@
-import { renderHook } from '@testing-library/react-hooks';
-import { of } from 'rxjs';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { of, of as mockOf, delay as mockDelay } from 'rxjs';
 import { DAYS_IN_A_YEAR, Decimal, getServices, ONE, SECONDS_IN_A_DAY } from 'tempus-core-services';
 import { getConfigManager } from '../config/getConfigManager';
 import { pool1, pool2, pool3, pool4, pool5 } from '../setupTests';
-import { useFixedAprs } from './useFixedAprs';
+import { useFixedAprs, subscribe, reset } from './useFixedAprs';
 
 jest.mock('tempus-core-services', () => ({
   ...jest.requireActual('tempus-core-services'),
   getServices: jest.fn(),
+}));
+
+jest.mock('./useServicesLoaded', () => ({
+  ...jest.requireActual('./useServicesLoaded'),
+  servicesLoaded$: mockOf(true).pipe(mockDelay(100)), // there is a chance that the mock subscribe and run before it mocks
 }));
 
 const mockGetDepositedEvents = jest.fn();
@@ -16,22 +21,10 @@ const mockGetSwapEvents = jest.fn();
 const mockEstimatedDepositAndFix = jest.fn();
 
 describe('useFixedAprs', () => {
-  let originalDateNow = Date.now;
-
-  beforeAll(async () => {
-    const config = getConfigManager();
-    await config.init();
-
-    jest.resetAllMocks();
-  });
+  beforeAll(getConfigManager);
 
   beforeEach(() => {
-    originalDateNow = Date.now;
-    Date.now = () => new Date(2022, 4, 15).getTime();
-  });
-
-  afterEach(() => {
-    Date.now = originalDateNow;
+    jest.spyOn(Date, 'now').mockReturnValue(new Date(2022, 4, 15).getTime());
   });
 
   it('returns `{}` as initial value', async () => {
@@ -48,9 +41,55 @@ describe('useFixedAprs', () => {
       },
     }));
 
+    act(() => {
+      reset();
+      subscribe();
+    });
+
     const { result } = renderHook(() => useFixedAprs());
 
     expect(result.current).toEqual({});
+  });
+
+  test('directly get the latest value for 2nd hooks', async () => {
+    (getServices as unknown as jest.Mock).mockImplementation(() => ({
+      TempusControllerService: {
+        getDepositedEvents: mockGetDepositedEvents.mockImplementation(() => []),
+        getRedeemedEvents: mockGetRedeemedEvents.mockImplementation(() => []),
+      },
+      VaultService: {
+        getSwapEvents: mockGetSwapEvents.mockImplementation(() => []),
+      },
+      StatisticsService: {
+        estimatedDepositAndFix: mockEstimatedDepositAndFix.mockImplementation(() => of<Decimal>(new Decimal('1.05'))),
+      },
+    }));
+
+    act(() => {
+      reset();
+      subscribe();
+    });
+
+    const { result: result1, waitForNextUpdate } = renderHook(() => useFixedAprs());
+
+    expect(result1.current).toEqual({});
+
+    await waitForNextUpdate();
+
+    const expected = {
+      'ethereum-1': new Decimal('0.018964322826463455'),
+      'ethereum-2': new Decimal('0.027805992889791775'),
+      'fantom-3': new Decimal('0.017293114339861025'),
+      'fantom-4': new Decimal('0.08514774494556765'),
+      'fantom-5': new Decimal('0.066043425814234015'),
+    };
+    expect(result1.current).toEqual(expected);
+    const functionCalledCount = (getServices as jest.Mock).mock.calls.length;
+
+    const { result: result2 } = renderHook(() => useFixedAprs());
+
+    expect(result2.current).toEqual(expected);
+    expect(getServices).toHaveBeenCalledTimes(functionCalledCount);
   });
 
   it('returns pool-to-APR map based on spot price', async () => {
@@ -68,6 +107,11 @@ describe('useFixedAprs', () => {
         estimatedDepositAndFix: mockEstimatedDepositAndFix.mockImplementation(() => of(principalsAmount)),
       },
     }));
+
+    act(() => {
+      reset();
+      subscribe();
+    });
 
     const { result, waitForNextUpdate } = renderHook(() => useFixedAprs());
 
@@ -92,6 +136,11 @@ describe('useFixedAprs', () => {
     jest.spyOn(console, 'error').mockImplementation();
     (getServices as unknown as jest.Mock).mockImplementation(() => {
       throw new Error();
+    });
+
+    act(() => {
+      reset();
+      subscribe();
     });
 
     const { result, waitForNextUpdate } = renderHook(() => useFixedAprs());

--- a/packages/tempus-client_v3/src/hooks/useFixedAprs.spec.ts
+++ b/packages/tempus-client_v3/src/hooks/useFixedAprs.spec.ts
@@ -83,12 +83,14 @@ describe('useFixedAprs', () => {
       'fantom-4': new Decimal('0.08514774494556765'),
       'fantom-5': new Decimal('0.066043425814234015'),
     };
-    expect(result1.current).toEqual(expected);
+    Object.entries(expected).forEach(([key, value]) => {
+      expect(parseFloat(value.toString())).toBeCloseTo(parseFloat(result1.current[key].toString()));
+    });
     const functionCalledCount = (getServices as jest.Mock).mock.calls.length;
 
     const { result: result2 } = renderHook(() => useFixedAprs());
 
-    expect(result2.current).toEqual(expected);
+    expect(result2.current).toEqual(result1.current);
     expect(getServices).toHaveBeenCalledTimes(functionCalledCount);
   });
 

--- a/packages/tempus-client_v3/src/hooks/useFixedAprs.ts
+++ b/packages/tempus-client_v3/src/hooks/useFixedAprs.ts
@@ -1,9 +1,11 @@
 import { bind } from '@react-rxjs/core';
 import {
+  BehaviorSubject,
   catchError,
   combineLatest,
   concatMap,
   debounce,
+  filter,
   from,
   interval,
   map,
@@ -13,6 +15,8 @@ import {
   of,
   scan,
   startWith,
+  Subscription,
+  tap,
 } from 'rxjs';
 import {
   getServices,
@@ -28,85 +32,103 @@ import {
   getDefaultProvider,
   ZERO,
 } from 'tempus-core-services';
+import { POLLING_INTERVAL_IN_MS, DEBOUNCE_IN_MS } from '../constants';
 import { poolList$ } from './usePoolList';
+import { servicesLoaded$ } from './useServicesLoaded';
+import { appEvent$ } from './useAppEvent';
 
 export interface PoolFixedAprMap {
   [chainPoolAddress: string]: Decimal;
 }
 
-// TODO all polling interval constants in a file?
-const APR_POLLING_INTERVAL_IN_MS = 120000;
-const DEBOUNCE_IN_MS = 500;
+const DEFAULT_VALUE = {};
 
-const intervalBeat$: Observable<number> = interval(APR_POLLING_INTERVAL_IN_MS).pipe(startWith(0));
+const intervalBeat$: Observable<number> = interval(POLLING_INTERVAL_IN_MS).pipe(startWith(0));
 
-export const poolAprs$: Observable<PoolFixedAprMap> = combineLatest([poolList$, intervalBeat$]).pipe(
-  mergeMap<[TempusPool[], number], Observable<PoolFixedAprMap>>(([tempusPools]) => {
-    const poolAprMaps = tempusPools.map(pool => {
-      const { address, poolId, chain, spotPrice, maturityDate } = pool;
+export const poolAprs$ = new BehaviorSubject<PoolFixedAprMap>(DEFAULT_VALUE);
 
-      if (maturityDate < Date.now()) {
-        return of({
-          [`${chain}-${address}`]: ZERO,
-        } as PoolFixedAprMap);
+const fetchData = (tempusPool: TempusPool): Observable<PoolFixedAprMap> => {
+  const { address, poolId, chain, spotPrice, maturityDate } = tempusPool;
+
+  if (maturityDate < Date.now()) {
+    return of({
+      [`${chain}-${address}`]: ZERO,
+    } as PoolFixedAprMap);
+  }
+
+  const tempusControllerService = getServices(chain as Chain)?.TempusControllerService as TempusControllerService;
+  const vaultService = getServices(chain as Chain)?.VaultService as VaultService;
+  const statisticsService = getServices(chain as Chain)?.StatisticsService as StatisticsService;
+
+  const tokenAmount = new Decimal(spotPrice);
+
+  const latestEventBlock$ = from(
+    Promise.all([
+      tempusControllerService.getDepositedEvents({ forPool: address }),
+      vaultService.getSwapEvents({ forPoolId: poolId }),
+      tempusControllerService.getRedeemedEvents({ forPool: address }),
+    ]).then(([depositedEvents, swapEvents, redeemedEvents]) => {
+      const allEvents = [...depositedEvents, ...swapEvents, ...redeemedEvents];
+      const latestEventBlockNumber = Math.max(0, ...allEvents.map(event => event.blockNumber));
+      const provider = getDefaultProvider(chain as Chain);
+
+      if (latestEventBlockNumber > 0) {
+        return provider.getBlock(latestEventBlockNumber);
       }
 
-      const tempusControllerService = getServices(chain as Chain)?.TempusControllerService as TempusControllerService;
-      const vaultService = getServices(chain as Chain)?.VaultService as VaultService;
-      const statisticsService = getServices(chain as Chain)?.StatisticsService as StatisticsService;
+      return undefined;
+    }),
+  );
 
-      const tokenAmount = new Decimal(spotPrice);
+  const principals$ = latestEventBlock$.pipe(
+    concatMap(latestEventBlock => {
+      const estimateCallOverrides =
+        latestEventBlock && latestEventBlock.number > 0 ? { blockTag: latestEventBlock.number } : undefined;
+      const estimateDepositAndFixFromBackingToken = true;
 
-      const latestEventBlock$ = from(
-        Promise.all([
-          tempusControllerService.getDepositedEvents({ forPool: address }),
-          vaultService.getSwapEvents({ forPoolId: poolId }),
-          tempusControllerService.getRedeemedEvents({ forPool: address }),
-        ]).then(([depositedEvents, swapEvents, redeemedEvents]) => {
-          const allEvents = [...depositedEvents, ...swapEvents, ...redeemedEvents];
-          const latestEventBlockNumber = Math.max(0, ...allEvents.map(event => event.blockNumber));
-          const provider = getDefaultProvider(chain as Chain);
-
-          if (latestEventBlockNumber > 0) {
-            return provider.getBlock(latestEventBlockNumber);
-          }
-
-          return undefined;
-        }),
+      return statisticsService.estimatedDepositAndFix(
+        tempusPool,
+        tokenAmount,
+        estimateDepositAndFixFromBackingToken,
+        estimateCallOverrides,
       );
+    }),
+  );
 
-      const principals$ = latestEventBlock$.pipe(
-        concatMap(latestEventBlock => {
-          const estimateCallOverrides =
-            latestEventBlock && latestEventBlock.number > 0 ? { blockTag: latestEventBlock.number } : undefined;
-          const estimateDepositAndFixFromBackingToken = true;
+  return combineLatest([latestEventBlock$, principals$]).pipe(
+    map(([latestEventBlock, principals]) => {
+      const currentFixedAPRTime = latestEventBlock ? latestEventBlock.timestamp * 1000 : Date.now();
+      const poolTimeRemaining = (maturityDate - currentFixedAPRTime) / 1000;
+      const scaleFactor = new Decimal((SECONDS_IN_A_DAY * DAYS_IN_A_YEAR) / poolTimeRemaining);
+      const ratio = principals.div(tokenAmount);
+      const pureInterest = ratio.sub(ONE);
 
-          return statisticsService.estimatedDepositAndFix(
-            pool,
-            tokenAmount,
-            estimateDepositAndFixFromBackingToken,
-            estimateCallOverrides,
-          );
-        }),
-      );
+      return {
+        [`${chain}-${address}`]: pureInterest.mul(scaleFactor),
+      } as PoolFixedAprMap;
+    }),
+  );
+};
 
-      return combineLatest([latestEventBlock$, principals$]).pipe(
-        map(([latestEventBlock, principals]) => {
-          const currentFixedAPRTime = latestEventBlock ? latestEventBlock.timestamp * 1000 : Date.now();
-          const poolTimeRemaining = (maturityDate - currentFixedAPRTime) / 1000;
-          const scaleFactor = new Decimal((SECONDS_IN_A_DAY * DAYS_IN_A_YEAR) / poolTimeRemaining);
-          const ratio = principals.div(tokenAmount);
-          const pureInterest = ratio.sub(ONE);
-
-          return {
-            [`${chain}-${address}`]: pureInterest.mul(scaleFactor),
-          } as PoolFixedAprMap;
-        }),
-      );
-    });
-
+// stream$ for periodic polling to fetch data
+const periodicStream$: Observable<PoolFixedAprMap> = combineLatest([poolList$, servicesLoaded$, intervalBeat$]).pipe(
+  filter(([, servicesLoaded]) => servicesLoaded),
+  mergeMap<[TempusPool[], boolean, number], Observable<PoolFixedAprMap>>(([tempusPools]) => {
+    const poolAprMaps = tempusPools.map(fetchData);
     return merge(...poolAprMaps);
   }),
+);
+
+// stream$ for listening to Tempus event to fetch specific pool data
+const eventStream$ = combineLatest([appEvent$, servicesLoaded$]).pipe(
+  filter(([, servicesLoaded]) => servicesLoaded),
+  mergeMap<[{ tempusPool: TempusPool }, boolean], Observable<PoolFixedAprMap>>(([{ tempusPool }]) =>
+    fetchData(tempusPool),
+  ),
+);
+
+// merge all stream$ into one
+const stream$ = merge(periodicStream$, eventStream$).pipe(
   scan(
     (allAprs, poolApr) => ({
       ...allAprs,
@@ -119,6 +141,16 @@ export const poolAprs$: Observable<PoolFixedAprMap> = combineLatest([poolList$, 
     console.error('useFixedAprs - Failed to fetch fixed APR for pools', error);
     return of({});
   }),
+  tap(poolTvls => poolAprs$.next(poolTvls)),
 );
 
 export const [useFixedAprs] = bind(poolAprs$, {});
+
+let subscription: Subscription = stream$.subscribe();
+
+export const subscribe = (): void => {
+  unsubscribe();
+  subscription = stream$.subscribe();
+};
+export const unsubscribe = (): void => subscription?.unsubscribe?.();
+export const reset = (): void => poolAprs$.next(DEFAULT_VALUE);

--- a/packages/tempus-client_v3/src/hooks/useMaturityTerm.spec.ts
+++ b/packages/tempus-client_v3/src/hooks/useMaturityTerm.spec.ts
@@ -44,9 +44,9 @@ describe('useMaturityTerm', () => {
     const poolTimeRemaining = (pool1.maturityDate - Date.now()) / 1000;
     const scalingFactor = new Decimal((SECONDS_IN_A_DAY * DAYS_IN_A_YEAR) / poolTimeRemaining);
 
-    expect(result.current).toEqual({
-      apr: principalsAmount.div(pool1.spotPrice).sub(ONE).mul(scalingFactor),
-      date: new Date(pool1.maturityDate),
-    });
+    expect(parseFloat(String(result.current?.apr))).toBeCloseTo(
+      parseFloat(principalsAmount.div(pool1.spotPrice).sub(ONE).mul(scalingFactor).toString()),
+    );
+    expect(result.current?.date).toEqual(new Date(pool1.maturityDate));
   });
 });

--- a/packages/tempus-client_v3/src/hooks/useMaturityTerm.spec.ts
+++ b/packages/tempus-client_v3/src/hooks/useMaturityTerm.spec.ts
@@ -1,54 +1,38 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { of } from 'rxjs';
-import { DAYS_IN_A_YEAR, Decimal, getServices, ONE, SECONDS_IN_A_DAY, TempusPool } from 'tempus-core-services';
+import { of as mockOf, delay as mockDelay } from 'rxjs';
+import {
+  DAYS_IN_A_YEAR,
+  Decimal,
+  Decimal as MockDecimal,
+  ONE,
+  SECONDS_IN_A_DAY,
+  TempusPool,
+} from 'tempus-core-services';
 import { getConfigManager } from '../config/getConfigManager';
 import { pool1 } from '../setupTests';
 import { useMaturityTermHook } from './useMaturityTerm';
 
-jest.mock('tempus-core-services', () => ({
-  ...jest.requireActual('tempus-core-services'),
-  getServices: jest.fn(),
+jest.mock('./useFixedAprs', () => ({
+  ...jest.requireActual('./useFixedAprs'),
+  poolAprs$: mockOf({
+    // principalsAmount = 1.05
+    'ethereum-1': new MockDecimal('0.018964322826463455'),
+    'ethereum-2': new MockDecimal('0.027805992889791775'),
+    'fantom-3': new MockDecimal('0.017293114339861025'),
+    'fantom-4': new MockDecimal('0.08514774494556765'),
+    'fantom-5': new MockDecimal('0.066043425814234015'),
+  }).pipe(mockDelay(100)),
 }));
 
-const mockGetDepositedEvents = jest.fn();
-const mockGetRedeemedEvents = jest.fn();
-const mockGetSwapEvents = jest.fn();
-const mockEstimatedDepositAndFix = jest.fn();
-
 describe('useMaturityTerm', () => {
-  let originalDateNow = Date.now;
-
-  beforeAll(async () => {
-    jest.resetAllMocks();
-
-    const config = getConfigManager();
-    await config.init();
-  });
+  beforeAll(getConfigManager);
 
   beforeEach(() => {
-    originalDateNow = Date.now;
-    Date.now = () => new Date(2022, 4, 15).getTime();
-  });
-
-  afterEach(() => {
-    Date.now = originalDateNow;
+    jest.spyOn(Date, 'now').mockReturnValue(new Date(2022, 4, 15).getTime());
   });
 
   it('returns a maturity term object from the selected pool', async () => {
     const principalsAmount = new Decimal('1.05');
-
-    (getServices as unknown as jest.Mock).mockImplementation(() => ({
-      TempusControllerService: {
-        getDepositedEvents: mockGetDepositedEvents.mockImplementation(() => []),
-        getRedeemedEvents: mockGetRedeemedEvents.mockImplementation(() => []),
-      },
-      VaultService: {
-        getSwapEvents: mockGetSwapEvents.mockImplementation(() => []),
-      },
-      StatisticsService: {
-        estimatedDepositAndFix: mockEstimatedDepositAndFix.mockImplementation(() => of(principalsAmount)),
-      },
-    }));
 
     const useMaturityTerm = useMaturityTermHook(pool1 as TempusPool);
     const { result, waitForNextUpdate } = renderHook(() => useMaturityTerm());

--- a/packages/tempus-client_v3/src/hooks/useMaturityTerm.ts
+++ b/packages/tempus-client_v3/src/hooks/useMaturityTerm.ts
@@ -1,5 +1,5 @@
 import { bind } from '@react-rxjs/core';
-import { map, Observable } from 'rxjs';
+import { filter, map, Observable } from 'rxjs';
 import { Decimal, TempusPool } from 'tempus-core-services';
 import { MaturityTerm } from '../interfaces';
 import { poolAprs$ } from './useFixedAprs';
@@ -7,6 +7,7 @@ import { poolAprs$ } from './useFixedAprs';
 export const maturityTerm$ = (sourceTempusPool: TempusPool): Observable<MaturityTerm> =>
   poolAprs$.pipe(
     map(aprsMap => aprsMap[`${sourceTempusPool.chain}-${sourceTempusPool.address}`]),
+    filter(apr => !!apr),
     map((apr: Decimal) => ({
       apr,
       date: new Date(sourceTempusPool.maturityDate),

--- a/packages/tempus-client_v3/src/hooks/useTvlData.spec.ts
+++ b/packages/tempus-client_v3/src/hooks/useTvlData.spec.ts
@@ -73,10 +73,12 @@ describe('useTvlData', () => {
       'fantom-5': new Decimal(8000),
     };
     expect(result1.current).toEqual(expected);
+    const functionCalledCount = (getServices as jest.Mock).mock.calls.length;
 
     const { result: result2 } = renderHook(() => useTvlData());
 
     expect(result2.current).toEqual(expected);
+    expect(getServices).toHaveBeenCalledTimes(functionCalledCount);
   });
 
   test('returns a empty map when there is error', async () => {

--- a/packages/tempus-client_v3/src/hooks/useTvlData.ts
+++ b/packages/tempus-client_v3/src/hooks/useTvlData.ts
@@ -17,22 +17,18 @@ import {
   tap,
 } from 'rxjs';
 import { getServices, Decimal, ZERO, StatisticsService, TempusPool, Chain } from 'tempus-core-services';
+import { POLLING_INTERVAL_IN_MS, DEBOUNCE_IN_MS } from '../constants';
 import { poolList$ } from './usePoolList';
 import { servicesLoaded$ } from './useServicesLoaded';
+import { appEvent$ } from './useAppEvent';
 
 interface PoolTvlMap {
   [chainPoolAddress: string]: Decimal;
 }
 
 const DEFAULT_VALUE = {};
-const TVL_POLLING_INTERVAL_IN_MS = 2 * 60 * 1000;
-const DEBOUNCE_IN_MS = 500;
 
-const polling$: Observable<number> = interval(TVL_POLLING_INTERVAL_IN_MS).pipe(startWith(0));
-// TODO: we dont have this event$ yet. this is a dummy event$ that gives tempusPool as param
-const event$: Observable<{ tempusPool: TempusPool }> = poolList$.pipe(
-  map(tempusPools => ({ tempusPool: tempusPools[0] })),
-);
+const intervalBeat$: Observable<number> = interval(POLLING_INTERVAL_IN_MS).pipe(startWith(0));
 
 export const poolTvls$ = new BehaviorSubject<PoolTvlMap>(DEFAULT_VALUE);
 
@@ -54,7 +50,7 @@ const fetchData = (tempusPool: TempusPool): Observable<PoolTvlMap> => {
 };
 
 // stream$ for periodic polling to fetch data
-const periodicStream$ = combineLatest([poolList$, servicesLoaded$, polling$]).pipe(
+const periodicStream$ = combineLatest([poolList$, servicesLoaded$, intervalBeat$]).pipe(
   filter(([, servicesLoaded]) => servicesLoaded),
   mergeMap<[TempusPool[], boolean, number], Observable<PoolTvlMap>>(([tempusPools]) => {
     const poolTvlMaps = tempusPools.map(fetchData);
@@ -64,7 +60,7 @@ const periodicStream$ = combineLatest([poolList$, servicesLoaded$, polling$]).pi
 );
 
 // stream$ for listening to Tempus event to fetch specific pool data
-const eventStream$ = combineLatest([event$, servicesLoaded$]).pipe(
+const eventStream$ = combineLatest([appEvent$, servicesLoaded$]).pipe(
   filter(([, servicesLoaded]) => servicesLoaded),
   mergeMap<[{ tempusPool: TempusPool }, boolean], Observable<PoolTvlMap>>(([{ tempusPool }]) => fetchData(tempusPool)),
 );


### PR DESCRIPTION
- introduce `constants.ts` to store all those hook constants
- separate `useAppEvent` for future Tempus app event hooks, with dummy implementation
- apply performance optimization on `useFixedAprs`
- mock `poolAprs$` for `useDepositModalData.spec.ts` and `useMaturityTerm.spec.ts`