### PR TITLE
useAppEvent to emit and listen application events

### DIFF
--- a/packages/tempus-client_v3/src/hooks/index.ts
+++ b/packages/tempus-client_v3/src/hooks/index.ts
@@ -18,3 +18,4 @@ export * from './useTokenList';
 export * from './useServicesLoaded';
 export * from './useApproveToken';
 export * from './useSigner';
+export * from './useAppEvent';

--- a/packages/tempus-client_v3/src/hooks/useAppEvent.spec.ts
+++ b/packages/tempus-client_v3/src/hooks/useAppEvent.spec.ts
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-dom/test-utils';
+import { Observable } from 'rxjs';
+import { Decimal, TempusPool } from 'tempus-core-services';
+import { pool1 } from '../setupTests';
+import { useAppEvent, AppEvent } from './useAppEvent';
+
+describe('useAppEvent', () => {
+  it('check default value to be null', () => {
+    const { result } = renderHook(() => useAppEvent());
+    const [appEvent] = result.current;
+
+    expect(appEvent).toBeNull();
+  });
+
+  it('receive events when emit a deposit event followed by a withdraw event', async () => {
+    const mockListener = jest.fn();
+    const depositEvent: AppEvent = {
+      eventType: 'deposit',
+      tempusPool: pool1 as TempusPool,
+      amount: new Decimal(100),
+      timestamp: Date.now() - 2000,
+    };
+    const withdrawEvent: AppEvent = {
+      eventType: 'withdraw',
+      tempusPool: pool1 as TempusPool,
+      amount: new Decimal(100),
+      timestamp: Date.now() - 1000,
+    };
+    const { appEvent$ } = require('./useAppEvent');
+    (appEvent$ as Observable<AppEvent>).subscribe(mockListener);
+
+    const { result, waitForNextUpdate } = renderHook(() => useAppEvent());
+    const [appEvent, emitAppEvent] = result.current;
+
+    expect(appEvent).toBeNull();
+
+    await act(async () => {
+      emitAppEvent(depositEvent);
+      await waitForNextUpdate();
+    });
+
+    expect(result.current[0]).toEqual(depositEvent);
+
+    await act(async () => {
+      emitAppEvent(withdrawEvent);
+      await waitForNextUpdate();
+    });
+
+    expect(result.current[0]).toEqual(withdrawEvent);
+    expect(mockListener).toHaveBeenNthCalledWith(1, depositEvent);
+    expect(mockListener).toHaveBeenNthCalledWith(2, withdrawEvent);
+  });
+});

--- a/packages/tempus-client_v3/src/hooks/useAppEvent.ts
+++ b/packages/tempus-client_v3/src/hooks/useAppEvent.ts
@@ -1,10 +1,23 @@
-import { map, Observable } from 'rxjs';
-import { TempusPool } from 'tempus-core-services';
-import { poolList$ } from './usePoolList';
+import { state, useStateObservable } from '@react-rxjs/core';
+import { createSignal } from '@react-rxjs/utils';
+import { Decimal, TempusPool } from 'tempus-core-services';
 
-// TODO: we dont have this event$ yet. this is a dummy event$ that gives tempusPool as param
-export const appEvent$: Observable<{ tempusPool: TempusPool }> = poolList$.pipe(
-  map(tempusPools => ({ tempusPool: tempusPools[0] })),
-);
+export type AppEventType = 'deposit' | 'withdraw';
 
-// TODO: we should have a hook for consumer to emit app event like deposit/withdraw
+export interface AppEvent {
+  eventType: AppEventType;
+  tempusPool: TempusPool;
+  amount: Decimal;
+  timestamp: number;
+}
+
+const [appEvent$, setAppEvent] = createSignal<AppEvent>();
+const stateAppEvent$ = state(appEvent$, null);
+
+export function useAppEvent(): [AppEvent | null, (value: AppEvent) => void] {
+  const appEvent = useStateObservable(stateAppEvent$);
+  const emitAppEvent = setAppEvent; // to remind to use for better naming only
+  return [appEvent, emitAppEvent];
+}
+
+export { appEvent$ };


### PR DESCRIPTION
- `useAppEvent` for emits and listening events (`deposit` and `withdraw` right now)
- `useFixedAprs` and `useTvlData` are now the listeners (will be more) and fetch data when receiving events
- 100% test coverage
- TODO: need to `emitAppEvent` when we do deposit and withdrawal