### PR TITLE
Improve app language support

### DIFF
--- a/packages/tempus-client_v3/src/hooks/useLocale.spec.ts
+++ b/packages/tempus-client_v3/src/hooks/useLocale.spec.ts
@@ -1,6 +1,12 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-dom/test-utils';
+import i18n, { SupportedLocale } from '../i18n';
 import { useLocale } from './useLocale';
+
+jest.mock('../i18n', () => ({
+  languages: ['en'],
+  changeLanguage: jest.fn<void, [SupportedLocale]>().mockImplementation(() => {}),
+}));
 
 describe('useLocale', () => {
   it('by default it return "en"', () => {
@@ -21,6 +27,9 @@ describe('useLocale', () => {
       await waitForNextUpdate();
     });
 
+    expect(i18n.changeLanguage).toBeCalledTimes(1);
+    expect(i18n.changeLanguage).toBeCalledWith('es');
+
     expect(result.current[0]).toEqual('es');
   });
 
@@ -34,6 +43,9 @@ describe('useLocale', () => {
       setLocale('it');
       await waitForNextUpdate();
     });
+
+    expect(i18n.changeLanguage).toBeCalledTimes(1);
+    expect(i18n.changeLanguage).toBeCalledWith('it');
 
     expect(result.current[0]).toEqual('it');
   });

--- a/packages/tempus-client_v3/src/hooks/useLocale.ts
+++ b/packages/tempus-client_v3/src/hooks/useLocale.ts
@@ -6,7 +6,7 @@ import i18n, { SupportedLocale } from '../i18n';
 
 const [rawLocale$, setLocale] = createSignal<SupportedLocale>();
 const locale$ = rawLocale$.pipe(distinctUntilChanged());
-const state$ = state(locale$, 'en');
+const state$ = state(locale$, i18n.languages[0] as SupportedLocale);
 
 export function useLocale(): [SupportedLocale, (value: SupportedLocale) => void] {
   const locale = useStateObservable(state$);

--- a/packages/tempus-client_v3/src/i18n/index.ts
+++ b/packages/tempus-client_v3/src/i18n/index.ts
@@ -10,6 +10,8 @@ i18n
   .init({
     resources,
     fallbackLng: 'en',
+    supportedLngs: SUPPORTED_LOCALES,
+    load: 'languageOnly',
     returnEmptyString: false,
 
     interpolation: {


### PR DESCRIPTION
1. Fallback to English if the user's initial locale is not supported
2. Use the user's initial locale as default app language
3. Keep the selected language after page refresh